### PR TITLE
fix: Vercel deploy — husky at root and monorepo build

### DIFF
--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -1,0 +1,7 @@
+{
+  "plugins": {
+    "notion-workspace": {
+      "enabled": true
+    }
+  }
+}

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Create a report to help us improve Venus AI
+about: Create a report to help us improve Aurora
 title: "fix: [Short Title of Bug]"
 labels: bug
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature Request
-about: Suggest an idea for Venus AI
+about: Suggest an idea for Aurora
 title: "feat: [Short Title of Feature]"
 labels: enhancement
 assignees: ''

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,12 @@
 ## Purpose
 What does this PR accomplish? (e.g. "Migrates Supabase auth", "Adds new profile modal")
 
-## Linear Ticket
-🎫 **Ticket Addressed:** `AUR-___` (if applicable)
+## Linear
+🎫 **Issue:** `INV-___` (required for feature/fix work — team key **INV**)
+
+**Branch:** If tied to Linear, prefer `feat/inv-___-short-slug` or `fix/inv-___-short-slug` (match the issue id).
+
+**Preview:** After CI, paste the **Vercel preview URL** if this change needs UI or auth verification.
 
 ## Type of Change
 - [ ] 🐛 Bug fix

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing to Aurora
+
+Thank you for helping improve Aurora. This project uses a small, deliberate workflow so a two-person team (and AI agents) can stay aligned without heavy process.
+
+## Before you write code
+
+1. **Track work in Linear** — Create or pick up an issue in the **Invincib1e** team. Issue ids use the **`INV`** prefix (for example `INV-42`).
+2. **Read** [`docs/workflow.md`](docs/workflow.md) for how Linear, Notion, GitHub, Vercel, and Supabase fit together.
+
+## Pull requests
+
+- Reference the Linear issue in the PR title or description (for example **`INV-42`**).
+- Prefer branch names that include the issue id, such as `feat/inv-42-short-description`.
+- Fill out [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md).
+- Confirm CI passes and, for UI or auth changes, verify the **Vercel preview** when available.
+- Do not commit secrets; document new environment variable **names** in the PR or in Notion, not values.
+
+## Local development
+
+See [`README.md`](README.md) for installing dependencies, environment variables, and running the dev server.
+
+## Questions
+
+Use your team’s usual channel, or leave context on the Linear issue so everyone (including agents) works from the same source of truth.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for helping improve Aurora. This project uses a small, deliberate work
 ## Before you write code
 
 1. **Track work in Linear** — Create or pick up an issue in the **Invincib1e** team. Issue ids use the **`INV`** prefix (for example `INV-42`).
-2. **Read** [`docs/workflow.md`](docs/workflow.md) for how Linear, Notion, GitHub, Vercel, and Supabase fit together.
+2. **Read** [`docs/README.md`](docs/README.md) for the doc map, then [`docs/workflow.md`](docs/workflow.md) for how Linear, Notion, GitHub, Vercel, and Supabase fit together.
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
-# Venus AI
+# Aurora
 
-Venus AI is a modern SaaS application built with a React + Vite frontend, Supabase for backend-as-a-service (authentication and database), Recoil for client state, and styled with Tailwind CSS v4.
+Aurora is a modern SaaS application built with a React + Vite frontend, Supabase for backend-as-a-service (authentication and database), Recoil for client state, and styled with Tailwind CSS v4.
 
 ## Structure
 
 - `frontend/` - React + Vite application, routing, UI components, Recoil state, and configuration.
 - `frontend/package.json` - Dependencies and build scripts for the frontend application.
-- `docs/` - Project notes and planning documentation.
+- `docs/` - Project notes and planning documentation. See `docs/workflow.md` for Linear, Notion, GitHub, Vercel, and Supabase.
+- `CONTRIBUTING.md` - How to contribute: Linear (`INV`), branches, PRs, and previews.
 
 The backend infrastructure has been completely migrated to **Supabase**, eliminating the need for a separate custom backend server. Authentication, data persistence, and real-time updates are all handled securely through the Supabase client.
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 Aurora is a modern SaaS application built with a React + Vite frontend, Supabase for backend-as-a-service (authentication and database), Recoil for client state, and styled with Tailwind CSS v4.
 
+**Repository:** [https://github.com/Aurora-091/venus-ai](https://github.com/Aurora-091/venus-ai)
+
 ## Structure
 
 - `frontend/` - React + Vite application, routing, UI components, Recoil state, and configuration.
 - `frontend/package.json` - Dependencies and build scripts for the frontend application.
-- `docs/` - Project notes and planning documentation. See `docs/workflow.md` for Linear, Notion, GitHub, Vercel, and Supabase.
+- `docs/` - Documentation hub: start at [`docs/README.md`](docs/README.md) (getting started, Linear↔GitHub, architecture, knowledge base).
 - `CONTRIBUTING.md` - How to contribute: Linear (`INV`), branches, PRs, and previews.
 
 The backend infrastructure has been completely migrated to **Supabase**, eliminating the need for a separate custom backend server. Authentication, data persistence, and real-time updates are all handled securely through the Supabase client.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,32 @@
+# Aurora documentation
+
+**Canonical repository:** [https://github.com/Aurora-091/venus-ai](https://github.com/Aurora-091/venus-ai)
+
+This folder is the **source-of-truth map** for engineers and agents. It starts minimal and grows with the product.
+
+| Doc | Purpose |
+|-----|---------|
+| [Getting started](getting-started.md) | Clone, install, env vars, run locally |
+| [Workflow (tools)](workflow.md) | How Linear, Notion, GitHub, Vercel, Supabase fit together |
+| [Linear ↔ GitHub](integrations/linear-github.md) | Connect the repo to Linear; branch and PR conventions |
+| [Knowledge base](knowledge/README.md) | What lives in git vs Notion; how to grow docs |
+| [Architecture overview](architecture/overview.md) | Repo layout, runtime picture, stack |
+| [Runbooks template](operations/runbooks-template.md) | Checklist for deploy / rollback / incidents (fill in) |
+
+## Project files elsewhere
+
+- [../CONTRIBUTING.md](../CONTRIBUTING.md) — PRs, `INV` issues, reviews
+- [../.github/PULL_REQUEST_TEMPLATE.md](../.github/PULL_REQUEST_TEMPLATE.md) — PR body
+
+## Older notes in repo
+
+| File | Notes |
+|------|--------|
+| [design.md](design.md) | VoiceOS-era design tokens (reuse or merge into current Aurora UI docs) |
+| [task.md](task.md) | Historical build checklist — not the live backlog (use **Linear**) |
+
+## Conventions
+
+- **Linear issue IDs** use team key **`INV`** (e.g. `INV-42`).
+- **Specs** that are short stay in Linear; longer write-ups go to **Notion** with the issue linked at the top.
+- **Secrets** never go in this repo—only variable *names* in docs when needed.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ This folder is the **source-of-truth map** for engineers and agents. It starts m
 | [Getting started](getting-started.md) | Clone, install, env vars, run locally |
 | [Workflow (tools)](workflow.md) | How Linear, Notion, GitHub, Vercel, Supabase fit together |
 | [Linear ↔ GitHub](integrations/linear-github.md) | Connect the repo to Linear; branch and PR conventions |
+| [Vercel](integrations/vercel.md) | Import repo, `frontend` root, env vars, preview deployments |
 | [Knowledge base](knowledge/README.md) | What lives in git vs Notion; how to grow docs |
 | [Architecture overview](architecture/overview.md) | Repo layout, runtime picture, stack |
 | [Runbooks template](operations/runbooks-template.md) | Checklist for deploy / rollback / incidents (fill in) |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,47 @@
+# Architecture overview (Aurora)
+
+High-level map. Update this file when the stack or repo layout changes.
+
+## Product shape
+
+- **SPA:** React + Vite under `frontend/`
+- **Backend services:** Primary persistence and auth through **Supabase** (Postgres, Auth, Realtime as used by the app)
+- **Hosting:** **Vercel** for the frontend (environment variables for build/runtime)
+- **Optional server:** `backend/` may run Node (Express, Socket.IO) for auxiliary APIs or realtime bridges—confirm what is deployed in production for your deployment; not every feature may use it
+
+## Request path (typical)
+
+1. User loads the Vercel-hosted SPA.
+2. The browser talks to **Supabase** via `@supabase/supabase-js` for auth, database, and realtime channels as implemented.
+3. Any separate HTTP/socket services depend on how you configure and deploy `backend/` (document your actual deployment when known).
+
+## Repository layout (conceptual)
+
+```
+venus-ai/
+├── frontend/          # Main UI — Vite, React, Tailwind v4, Recoil
+├── backend/           # Optional Node server (if used in your environment)
+├── docs/              # This documentation set
+└── .github/           # CI, PR template, issue templates
+```
+
+## Environments
+
+| Environment | Role |
+|-------------|------|
+| **Local** | `frontend/.env` — Supabase URL + anon key; never commit secrets |
+| **Vercel Preview** | Per-PR builds; validate UI and API calls against a dev/staging Supabase if you use one |
+| **Vercel Production** | Production Supabase project and domains |
+
+Document **which Supabase project** maps to preview vs production in Notion or in this doc when you finalize it.
+
+## CI
+
+GitHub Actions (see `.github/workflows/ci.yml`) runs install, format check, lint, typecheck, and build for the frontend on pushes and PRs to `main`.
+
+## Future additions
+
+When you add topics worth a dedicated page:
+
+- Data model and RLS overview (link to migrations / Supabase SQL)
+- Third-party integrations (Google APIs, etc.) as implemented in `backend/` or Edge Functions

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,56 @@
+# Getting started (Aurora)
+
+For developers joining the repo or setting up a new machine.
+
+## Prerequisites
+
+- **Node.js** 20.x (matches CI; see `.github/workflows/ci.yml`)
+- **npm** (lockfiles are committed under `frontend/` and `backend/` as applicable)
+- Access to **Supabase** (project URL + anon key for local dev)
+- Access to **GitHub** org/repo and **Linear** (Invincib1e / `INV`)
+
+## Clone and install
+
+```bash
+git clone https://github.com/Aurora-091/venus-ai.git
+cd venus-ai
+```
+
+Frontend (primary app):
+
+```bash
+cd frontend
+npm ci
+cp .env.example .env
+```
+
+Edit `frontend/.env` with your Supabase values:
+
+- `VITE_SUPABASE_URL`
+- `VITE_SUPABASE_ANON_KEY`
+
+## Run the app
+
+From `frontend/`:
+
+```bash
+npm run dev
+```
+
+Default dev URL: `http://127.0.0.1:5682` (see `frontend/package.json`).
+
+## Monorepo scripts (repo root)
+
+From the repository root, `package.json` may define shortcuts such as `npm run dev` running both frontend and backend. If you only need the UI, working in `frontend/` is enough.
+
+## Verify
+
+- [ ] `npm run type-check` (from `frontend/`) passes
+- [ ] `npm run build` (from `frontend/`) passes
+- [ ] App loads and auth flows match your Supabase project if you test login
+
+## Next
+
+- [Workflow](workflow.md) — how we use Linear and PRs  
+- [Linear ↔ GitHub](integrations/linear-github.md) — connect your GitHub repo  
+- [Architecture](architecture/overview.md) — where code and services live  

--- a/docs/integrations/linear-github.md
+++ b/docs/integrations/linear-github.md
@@ -1,0 +1,88 @@
+# Connect Linear to the GitHub repository
+
+**Canonical repo:** [Aurora-091/venus-ai](https://github.com/Aurora-091/venus-ai)
+
+Use this when you are **starting from scratch**: no GitHub link in Linear yet, or you moved the repo to a new org.
+
+## What you get after connecting
+
+- Open a **Linear issue** → create a **branch name** / **copy** that includes `INV-123`
+- **Pull requests** on GitHub can **link** to Linear issues (and optionally move status when merged—depends on your Linear automation settings)
+- Developers see **repo activity** next to engineering work in one place
+
+Linear’s UI changes occasionally; if a label differs, use **Settings → Integrations** and search for **GitHub**.
+
+---
+
+## Step 1 — GitHub side (org or repo access)
+
+1. Ensure repositories live under your **GitHub organization** (e.g. `Aurora-091/venus-ai`).
+2. Decide which repos Linear may access: usually **only the Aurora app repo** (least privilege).
+
+You must have **admin** or sufficient rights on the org/repo to install GitHub Apps for the org.
+
+---
+
+## Step 2 — Linear: install the GitHub integration
+
+1. Open **Linear** in the browser.
+2. Go to **Settings** (workspace or your profile, depending on plan).
+3. Open **Integrations** (or **Workspace → Integrations**).
+4. Find **GitHub** and choose **Connect** / **Add**.
+5. Complete OAuth and select the **organization** and **repositories** (e.g. `venus-ai`).
+6. Save.
+
+If Linear asks for a **Personal Access Token** in older flows, prefer the **GitHub App** integration when offered—it is easier to scope per repo.
+
+---
+
+## Step 3 — Map the Aurora repo (automation)
+
+Still under the GitHub integration in Linear:
+
+1. Confirm the **`Aurora-091/venus-ai`** repo appears in the list.
+2. Enable options that match how you want to work, for example:
+   - **Link PRs** when the title or branch contains `INV-` / issue URL
+   - **Auto-assign** or **move to In Progress** when a branch is created (optional)
+   - **Done** when PR merges to default branch (optional—popular for small teams)
+
+Exact toggles vary; pick **minimal automation** first, then add more once the team agrees.
+
+---
+
+## Step 4 — Team conventions (align with this repo)
+
+- **Issue prefix:** `INV` (team **Invincib1e**).
+- **PR title example:** `INV-12 Add pricing page` or `[INV-12] Add pricing page`
+- **Branch example:** `feat/inv-12-pricing-page` (from Linear’s “Copy git branch name” when available)
+
+Our [PR template](../../.github/PULL_REQUEST_TEMPLATE.md) asks for the **`INV-___`** line—keep that habit.
+
+---
+
+## Step 5 — Verify end-to end
+
+1. Create a **test issue** in Linear (or use a small real task).
+2. In Linear, use **Copy branch name** (if available) and create a branch locally, commit a trivial doc fix, open a **PR** to `main`.
+3. Confirm the **PR shows the Linear link** in GitHub or Linear (depending on integration).
+4. Merge the PR; confirm the issue **moves to Done** if you enabled that automation.
+
+Delete the test issue or close it cleanly.
+
+---
+
+## Troubleshooting
+
+| Problem | What to try |
+|---------|----------------|
+| Linear cannot see the org | Re-authorize GitHub; check org **Third-party access** / **OAuth app** restrictions |
+| PR does not link | Put `INV-123` in the **PR title** or **description**; ensure repo is selected in Linear |
+| Wrong repo connected | Linear → GitHub integration → adjust repository list |
+| Fork vs org repo | Connect the **canonical org repo**, not a personal fork, for production work |
+
+---
+
+## Related
+
+- [Workflow (tools)](../workflow.md) — full tool chain  
+- [Contributing](../../CONTRIBUTING.md) — PR checklist  

--- a/docs/integrations/vercel.md
+++ b/docs/integrations/vercel.md
@@ -1,0 +1,88 @@
+# Vercel: connect repo and enable previews (Aurora)
+
+The UI lives in **`frontend/`** (Vite). Point the Vercel project at that folder so builds do not run from the monorepo root by mistake.
+
+**Repository:** [Aurora-091/venus-ai](https://github.com/Aurora-091/venus-ai)
+
+---
+
+## 1. Import the GitHub repository
+
+1. Open [Vercel Dashboard](https://vercel.com/dashboard) → **Add New…** → **Project**.
+2. **Import** [Aurora-091/venus-ai](https://github.com/Aurora-091/venus-ai).  
+   - If the org does not appear, install the Vercel GitHub App for **Aurora-091** and grant access to this repo.
+3. Before deploying, open **Configure Project** (or **Settings** after import).
+
+---
+
+## 2. Root directory and build
+
+**Default (current):** The repo has a root [`vercel.json`](https://github.com/Aurora-091/venus-ai/blob/main/vercel.json) so deployments that use the **repository root** install both root + `frontend` dependencies and build with `npm run build --prefix frontend`. Leave **Root Directory** empty / `.` in the Vercel project if you rely on this.
+
+**Alternative:** Set **Root Directory** to `frontend` only. Then Vercel ignores the root `vercel.json` and uses [`frontend/vercel.json`](https://github.com/Aurora-091/venus-ai/blob/main/frontend/vercel.json) (Vite, `dist`, SPA rewrites). Root `npm install` is not used in that mode.
+
+| Setting | Root deploy (`.`) | Subfolder deploy (`frontend`) |
+|--------|---------------------|-------------------------------|
+| **Install** | See root `vercel.json` `installCommand` | `npm ci` in `frontend/` |
+| **Build** | `npm run build --prefix frontend` | `npm run build` |
+| **Output** | `frontend/dist` | `dist` |
+
+---
+
+## 3. Environment variables
+
+In the project → **Settings** → **Environment Variables**, add (names from [`frontend/.env.example`](https://github.com/Aurora-091/venus-ai/blob/main/frontend/.env.example)):
+
+| Name | Production | Preview | Development |
+|------|------------|---------|---------------|
+| `VITE_SUPABASE_URL` | Your Supabase project URL | Same or a **staging** Supabase URL | Optional |
+| `VITE_SUPABASE_ANON_KEY` | Anon key | Staging anon key if you use a separate project | Optional |
+| `VITE_API_BASE_URL` | `/api` or your deployed API base URL | Same as prod or staging API | `/api` |
+
+Enable **Preview** and **Production** (and Development if you use `vercel dev`) for each variable as appropriate.
+
+Redeploy after changing env vars.
+
+---
+
+## 4. Enable preview deployments (PR previews)
+
+Previews are **on by default** when the project is connected to GitHub.
+
+1. **Settings** → **Git**:
+   - Confirm the linked repository is **Aurora-091/venus-ai**.
+   - **Production Branch** is usually `main` (adjust if your default branch differs).
+2. **Preview Branches**: leave **All branches** (or restrict if your org policy requires it).
+3. Optional: enable **Comments** / **Commit status** so GitHub shows preview links on pull requests.
+
+Open a test PR targeting `main`; you should see a **Preview** deployment and a unique `*.vercel.app` URL on the PR.
+
+---
+
+## 5. Production domain
+
+After the first successful deploy: **Settings** → **Domains** — add your custom domain when ready.
+
+---
+
+## 6. Verify
+
+- [ ] A push to `main` creates a **Production** deployment.
+- [ ] A PR creates a **Preview** deployment with a working app (check Supabase keys for that environment).
+- [ ] Client-side routes (e.g. dashboard URLs) load on refresh — helped by `rewrites` in `frontend/vercel.json`.
+
+---
+
+## Troubleshooting
+
+| Issue | What to check |
+|--------|----------------|
+| Build runs at repo root | **Root Directory** must be `frontend`. |
+| Blank page on refresh | Ensure `vercel.json` `rewrites` are present and redeploy. |
+| Wrong API URL on preview | Set `VITE_API_BASE_URL` per environment in Vercel. |
+| Env not applied | Scope variables to Preview vs Production; trigger a new deployment. |
+
+## Related
+
+- [Workflow (tools)](../workflow.md) — Vercel in the stack  
+- [Getting started](../getting-started.md) — local `VITE_*` vars  

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -1,0 +1,62 @@
+# Knowledge base (Aurora)
+
+You are building documentation **from scratch**. Use this split so nothing duplicates and agents always have a clear place to look.
+
+## Principles
+
+| Location | Put here |
+|----------|-----------|
+| **This repo (`docs/`)** | Things that must version with code: architecture boundaries, env var *names*, runbook steps tied to releases, ADRs that affect implementation |
+| **Notion** | Long-form specs, meeting notes, stakeholder context, **links hub** (one page listing Linear, GitHub, Vercel, Supabase URLs) |
+| **Linear** | Tasks, acceptance criteria, *short* context in the issue body |
+
+**Do not** maintain two parallel backlogs (Notion tasks + Linear). **Linear owns execution.**
+
+---
+
+## Suggested Notion structure (create empty, then fill)
+
+Create a workspace or top-level page **Aurora** with children:
+
+1. **Home** — Bullet list of links only: Linear team, [github.com/Aurora-091/venus-ai](https://github.com/Aurora-091/venus-ai), Vercel project, Supabase project, production URL(s).
+2. **Engineering** — Link to the docs hub: [github.com/Aurora-091/venus-ai/blob/main/docs/README.md](https://github.com/Aurora-091/venus-ai/blob/main/docs/README.md), plus 5 bullets: branch naming, PR process, on-call (TBD).
+3. **Specs** — One page per major feature OR a simple database: Title | Owner | Linear link | Status | Figma link.
+4. **Runbooks** — One page each: Deploy, Rollback, Env vars overview (names only), Incident checklist.
+5. **Decisions** — Short ADR-style pages: Problem → Decision → Consequences (optional).
+
+Invite the second teammate as **full** or **edit** as needed.
+
+---
+
+## Suggested git documentation (this repo)
+
+Grow these files as you learn:
+
+| File | When to update |
+|------|------------------|
+| `docs/architecture/overview.md` | When stack or boundaries change |
+| `docs/operations/runbooks-template.md` | First time you deploy or cut over prod |
+| `docs/integrations/linear-github.md` | If integration steps change |
+
+---
+
+## Connect Notion ↔ Linear (in Notion)
+
+In **Notion Settings** → **Connections** (or **Integrations**):
+
+- Add **Linear** if listed, and authorize.
+- That lets you **mention or embed** Linear issues in Notion pages and improves cross-search for teams on Notion AI plans.
+
+This is configured in **Notion**, not in git.
+
+---
+
+## Agents (Cursor / Codex)
+
+Give an agent:
+
+1. A **Linear issue** with a one-line **definition of done**
+2. An optional **Notion** spec URL for background
+3. Pointers to **`docs/`** when changing architecture
+
+Review all PRs that touch **RLS**, **auth**, or **production env**.

--- a/docs/operations/runbooks-template.md
+++ b/docs/operations/runbooks-template.md
@@ -1,0 +1,37 @@
+# Runbooks (template)
+
+Copy sections into dedicated pages in **Notion** or expand this file when procedures become stable. Keep secrets out—reference **names** of env vars only.
+
+## Deploy (production)
+
+**Owner:** _name_  
+**Approvers:** _name_
+
+- [ ] Linear release issue: `INV-___`
+- [ ] `main` is green (CI) and reviewed
+- [ ] Vercel production deployment: _link to dashboard or deployment_
+- [ ] Supabase migration applied (if any): _reference migration id or file_
+- [ ] Smoke test: _checklist (login, critical path)_
+- [ ] Communicate: _Slack/email if used_
+
+## Rollback
+
+- [ ] Identify last known good Vercel deployment: _how you find it (dashboard)_
+- [ ] Promote rollback or revert Git: _team procedure_
+- [ ] Verify Supabase state if migrations were forward-only: _contact / runbook_
+
+## Incident (sev / user impact)
+
+- [ ] Triage: what broke, scope, start time
+- [ ] Mitigate: feature flag, revert, scale (as applicable)
+- [ ] Communicate: _status page or channel_
+- [ ] Post-incident: Linear issue for follow-up, short notes in Notion **Decisions** or **Incidents**
+
+## Environment variables (reference)
+
+| Name (Vercel / app) | Purpose | Updated when |
+|---------------------|---------|----------------|
+| `VITE_SUPABASE_URL` | Supabase project URL | New project / cutover |
+| `VITE_SUPABASE_ANON_KEY` | Public anon key | Rotation policy TBD |
+
+_Add backend or server-only vars here if you use them._

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -44,6 +44,8 @@ Create a small **Aurora** space:
 - Document **which variables** live in Vercel (typically `VITE_*` for the SPA) vs the Supabase dashboard — **names only**, never values in git.
 - For each PR: confirm the **Vercel preview URL** and that auth/data paths still work if you touched Supabase-related code.
 
+**Setup:** [integrations/vercel.md](integrations/vercel.md) (import GitHub repo, root vs `frontend` deploy options, previews).
+
 ## AI agents (Cursor / Codex)
 
 - Give agents a **Linear issue** with a clear acceptance sentence and optional Notion link for background.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,52 @@
+# Aurora — engineering workflow
+
+This document describes how **Aurora** uses **Linear**, **Notion**, **GitHub**, **Vercel**, and **Supabase** together. It is optimized for a **small team** (two people) plus **AI agents** (Cursor, Codex): enough structure to stay aligned, not enough to slow you down.
+
+## Roles of each tool
+
+| Tool | Owns |
+|------|------|
+| **Linear** | Backlog, priorities, cycles, and *what ships*. Single source of truth for tasks. |
+| **Notion** | Narrative context: specs, runbooks, ADRs, meeting notes. *Not* a duplicate task list. |
+| **GitHub** | Code, pull requests, CI, and review. |
+| **Vercel** | Frontend hosting, preview deployments per PR, environment variables for the app. |
+| **Supabase** | Auth, Postgres, RLS, Realtime, and project settings in the Supabase dashboard. |
+
+## Linear workspace
+
+- **Team:** Invincib1e (Linear team key: **`INV`** — issue IDs look like `INV-123`).
+- **Projects:** Platform · Product · Supabase · Ops & incidents (group work by theme).
+- **Labels:** `area: frontend`, `area: backend`, `area: supabase`, `type: chore`, `platform: vercel`, plus workspace labels Bug / Feature / Improvement.
+
+Create work in Linear first, then branch and open a PR that references the issue.
+
+## GitHub ↔ Linear
+
+1. In Linear: **Settings → Integrations → GitHub** — connect the org repository that hosts Aurora.
+2. Prefer **PR titles** that include the issue id, e.g. `INV-42 Add booking export`.
+3. Use **branch names** that match Linear when helpful, e.g. `feat/inv-42-booking-export` (Linear can suggest a branch from an issue).
+
+## Notion (recommended layout)
+
+Create a small **Aurora** space:
+
+1. **Home** — Bookmark links: Linear, this GitHub repo, Vercel project, Supabase project, production URL.
+2. **Engineering** — Short notes: branch naming, PR checklist, who updates Vercel vs Supabase settings.
+3. **Runbooks** — Deploy, rollback, key rotation, incident checklist (expand as needed).
+4. **Specs** (optional database) — Title, owner, link to Linear issue, link to design.
+
+**Rule:** If it fits in one Linear issue description, keep it there. Use Notion when you need a longer spec or a durable runbook.
+
+## Vercel + Supabase
+
+- Document **which variables** live in Vercel (typically `VITE_*` for the SPA) vs the Supabase dashboard — **names only**, never values in git.
+- For each PR: confirm the **Vercel preview URL** and that auth/data paths still work if you touched Supabase-related code.
+
+## AI agents (Cursor / Codex)
+
+- Give agents a **Linear issue** with a clear acceptance sentence and optional Notion link for background.
+- Keep the human as **reviewer** for merges and for anything touching RLS or production config.
+
+## Starter epic in Linear
+
+An epic **“Aurora engineering workflow”** and child tasks for Notion setup, GitHub integration, and env/preview documentation may already exist under the **Platform** project — use those as your onboarding checklist.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -26,6 +26,8 @@ Create work in Linear first, then branch and open a PR that references the issue
 2. Prefer **PR titles** that include the issue id, e.g. `INV-42 Add booking export`.
 3. Use **branch names** that match Linear when helpful, e.g. `feat/inv-42-booking-export` (Linear can suggest a branch from an issue).
 
+**Step-by-step:** see [integrations/linear-github.md](integrations/linear-github.md).
+
 ## Notion (recommended layout)
 
 Create a small **Aurora** space:

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "installCommand": "npm ci",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "aurora",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "aurora",
+      "devDependencies": {
+        "husky": "^9.1.7"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "aurora",
   "description": "Aurora — React + Vite frontend, Supabase, optional Node server (Express/Socket.IO), styled with Tailwind CSS v4",
   "private": true,
+  "devDependencies": {
+    "husky": "^9.1.7"
+  },
   "scripts": {
     "build": "npm --prefix frontend run build",
     "cf-typegen": "npm --prefix backend run cf-typegen",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "aurora-test-0093",
-  "description": "A MERN application with React, Recoil, Express, MongoDB, and Socket.IO",
+  "name": "aurora",
+  "description": "Aurora — React + Vite frontend, Supabase, optional Node server (Express/Socket.IO), styled with Tailwind CSS v4",
   "private": true,
   "scripts": {
     "build": "npm --prefix frontend run build",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "npm ci && npm ci --prefix frontend",
+  "buildCommand": "npm run build --prefix frontend",
+  "outputDirectory": "frontend/dist",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## Purpose

Fix **Vercel production deploy** failing during `npm install` when the root `prepare` script runs **Husky** but the `husky` binary was not installed at the repository root. Align **monorepo** deployment with a root `vercel.json` that installs dependencies at the repo root and builds the **Vite** app in `frontend/` to `frontend/dist`, with SPA rewrites documented.

**Included in this branch (vs `main`):**

- Root **`package.json`**: add `husky` as a **devDependency** so `npm install` / `npm ci` at the repo root provides the `husky` command used by `prepare`.
- Root **`package-lock.json`**: lockfile for reproducible `npm ci` on Vercel.
- Root **`vercel.json`**: install at monorepo root, run `npm run build` (which builds `frontend` per root scripts), output **`frontend/dist`**, SPA rewrites.
- **`frontend/vercel.json`**: retained for deployments that use **Root Directory = `frontend`** only.
- **`docs/integrations/vercel.md`**: updated to describe **root** vs **`frontend`** Root Directory; linked from **`docs/README.md`** and **`docs/workflow.md`**.

## Linear

🎫 **Issue:** `INV-10` (platform / Vercel & knowledge base checklist — adjust if you track elsewhere)

**Branch:** `fix/vercel-deploy-husky-and-monorepo-build`

**Preview:** After CI, paste the **Vercel preview URL** for the latest deployment of this branch.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💄 UI/UX styling
- [ ] 🛠️ Refactoring / Technical Debt
- [x] 📚 Documentation

## Checklist

Before asking for a review, please verify the following:

- [x] My code strictly follows the application's aesthetic guidelines (Tailwind CSS, glassmorphism, responsive). *(No UI changes in the fix commit.)*
- [x] I have verified this behavior locally.
- [x] Any `.env` changes required have been securely documented in `README.md` or Notion, and never committed to Git. *(No new secrets; Vercel env vars unchanged in this PR.)*
- [ ] CI Pipeline checks are currently passing.

## Video / Screenshots

N/A — infrastructure and documentation.

## Review Priority

- [ ] 🚨 Urgent (Hotfix for production)
- [x] 🟠 High (Blocks other work)
- [ ] 🟢 Normal / Low

## Additional Comments

- **Failure addressed:** deploy `dpl_ECMk6bmvm4Cf77WH2qv6PaEbhTFH` failed with `husky: command not found` during `prepare` when the install context was the monorepo root without root `husky`.
- **Vercel project settings:** If the project uses **Root Directory = repo root**, rely on root `vercel.json`. If **Root Directory = `frontend`**, `frontend/vercel.json` applies; ensure Husky still runs only where `prepare` is expected (root vs frontend).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts Vercel build/install commands and introduces a new root lockfile; misconfiguration could break production/preview deployments even though no runtime app logic changes.
> 
> **Overview**
> Fixes Vercel deploys when building from the monorepo root by adding `husky` as a root dev dependency (with a new root `package-lock.json`) so the existing `prepare` step can run during `npm ci`.
> 
> Adds a root `vercel.json` that installs dependencies at the repo root + `frontend/`, builds the Vite app to `frontend/dist`, and applies SPA rewrites; also adds `frontend/vercel.json` for projects configured with `Root Directory = frontend`.
> 
> Standardizes repo workflow docs/templates and naming to **Aurora** (issue/PR templates, new `CONTRIBUTING.md`, and a new `docs/` hub including Vercel + Linear integration guides and runbook templates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09620d2c273b398d548f14668421b088ffab6d88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->