### PR TITLE
docs: sync getting-started (env, ports, Notion hub)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,13 +1,13 @@
 # Getting started (Aurora)
 
-For developers joining the repo or setting up a new machine.
+For developers and agents setting up a new machine. **Canonical doc map:** [`docs/README.md`](README.md).
 
 ## Prerequisites
 
-- **Node.js** 20.x (matches CI; see `.github/workflows/ci.yml`)
-- **npm** (lockfiles are committed under `frontend/` and `backend/` as applicable)
-- Access to **Supabase** (project URL + anon key for local dev)
-- Access to **GitHub** org/repo and **Linear** (Invincib1e / `INV`)
+- **Node.js** **24.x** (matches [`.github/workflows/ci.yml`](../.github/workflows/ci.yml); use `nvm` or similar if needed)
+- **npm** (lockfiles: `frontend/package-lock.json`, `backend/package-lock.json`)
+- **Supabase** project (URL + anon key for the browser; service role key only on the server)
+- Org access: **GitHub** repo, **Linear** (Invincib1e / `INV`) as needed
 
 ## Clone and install
 
@@ -16,7 +16,7 @@ git clone https://github.com/Aurora-091/venus-ai.git
 cd venus-ai
 ```
 
-Frontend (primary app):
+### Frontend (Vite + React)
 
 ```bash
 cd frontend
@@ -24,33 +24,112 @@ npm ci
 cp .env.example .env
 ```
 
-Edit `frontend/.env` with your Supabase values:
+Edit `frontend/.env`. Names must match the example file:
 
-- `VITE_SUPABASE_URL`
-- `VITE_SUPABASE_ANON_KEY`
-
-## Run the app
-
-From `frontend/`:
+| Variable | Purpose |
+|----------|---------|
+| `VITE_SUPABASE_URL` | Supabase project URL |
+| `VITE_SUPABASE_ANON_KEY` | Supabase anon (public) key |
+| `VITE_API_BASE_URL` | API base path. Use **`/api`** locally so Vite proxies to the backend (see below). |
 
 ```bash
 npm run dev
 ```
 
-Default dev URL: `http://127.0.0.1:5682` (see `frontend/package.json`).
+- **Dev URL:** `http://127.0.0.1:5682` (fixed in `frontend/package.json`)
+- **Local API:** With `VITE_API_BASE_URL=/api`, the dev server proxies **`/api`** → `http://127.0.0.1:5000` and **`/socket.io`** → `ws://127.0.0.1:5000` (`frontend/vite.config.ts`). Run the backend on port **5000** for full-stack features.
 
-## Monorepo scripts (repo root)
+### Backend (Express + Socket.IO) — optional
 
-From the repository root, `package.json` may define shortcuts such as `npm run dev` running both frontend and backend. If you only need the UI, working in `frontend/` is enough.
+Use when you need `/api`, WebSockets, or server-side integrations (Twilio, ElevenLabs, Google, etc.).
 
-## Verify
+```bash
+cd backend
+npm ci
+cp .env.example .env
+```
 
-- [ ] `npm run type-check` (from `frontend/`) passes
-- [ ] `npm run build` (from `frontend/`) passes
-- [ ] App loads and auth flows match your Supabase project if you test login
+Edit `backend/.env`:
+
+| Variable | Default / notes |
+|----------|-----------------|
+| `PORT` | **`5000`** (must match the Vite proxy) |
+| `CLIENT_ORIGIN` | **`http://127.0.0.1:5682`** (CORS + Socket.IO) |
+| `SUPABASE_URL` | Same project URL as the frontend |
+| `SUPABASE_SERVICE_ROLE_KEY` | Service role key (**server only**; never in Vite env) |
+| `ELEVENLABS_API_KEY` | Required for real agent creation / voice paths when used |
+| `TWILIO_ACCOUNT_SID` | Required for outbound calls when used |
+| `TWILIO_AUTH_TOKEN` | |
+| `TWILIO_PHONE_NUMBER` | |
+| `GOOGLE_CLIENT_ID` | Optional Google integrations |
+| `GOOGLE_CLIENT_SECRET` | |
+
+```bash
+npm run dev
+```
+
+**Listen address:** `http://127.0.0.1:5000` (API + Socket.IO on the same port).
+
+### Run frontend + backend together
+
+From the **repository root**, do **not** rely on `npm run dev` in the root `package.json` on Linux or macOS (it points at a Windows `concurrently.cmd` path). Use two terminals or one shell with `npx concurrently`, for example:
+
+**Terminal A — backend**
+
+```bash
+npm --prefix backend run dev
+```
+
+**Terminal B — frontend**
+
+```bash
+npm --prefix frontend run dev
+```
+
+**One-liner (from repo root, any OS):**
+
+```bash
+npx --yes concurrently -k -n backend,frontend -c green,cyan "npm --prefix backend run dev" "npm --prefix frontend run dev"
+```
+
+Other root shortcuts that work cross-platform:
+
+| Command | What it does |
+|---------|----------------|
+| `npm run dev:client` | Frontend only |
+| `npm run dev:server` | Backend only |
+| `npm run build` | Production build of `frontend/` (same idea as Vercel root build) |
+| `npm run check` | `vite build` in `frontend/` (alias for CI-style check) |
+
+## Database schema (Supabase)
+
+Provision tables and RLS in the Supabase SQL editor using the versioned script:
+
+- **`backend/supabase_schema.sql`**
+
+There are no `npm run db:*` scripts in `backend/package.json` today; ignore stale references to them unless they are reintroduced.
+
+## Verify (frontend)
+
+From `frontend/`:
+
+```bash
+npm run type-check
+npm run lint
+npm run build
+```
+
+CI runs **Prettier check**, **ESLint**, **type-check**, and **build** on `frontend/` with Node **24.x**.
+
+## User-visible flows to smoke-test
+
+- App loads at `http://127.0.0.1:5682`
+- **Supabase Auth** (email/OAuth) matches your project settings if you test login
+- With backend running: API routes under `/api` and realtime features that depend on Socket.IO
 
 ## Next
 
-- [Workflow](workflow.md) — how we use Linear and PRs  
-- [Linear ↔ GitHub](integrations/linear-github.md) — connect your GitHub repo  
-- [Architecture](architecture/overview.md) — where code and services live  
+- [Workflow](workflow.md) — Linear, Notion, GitHub, Vercel, Supabase  
+- [Linear ↔ GitHub](integrations/linear-github.md) — connect the repo  
+- [Vercel](integrations/vercel.md) — `frontend/` vs root deploy, env vars on hosting  
+- [Architecture](architecture/overview.md) — layout and runtime  

--- a/docs/notion-aurora-hub.md
+++ b/docs/notion-aurora-hub.md
@@ -22,14 +22,11 @@ Under it, create **empty child pages** with these titles:
 
 ## Step 2 — Fill **Home** with links (copy-paste)
 
-Put these on **Home** as a bullet list (adjust URLs if yours differ):
+Put **at most three** bullets on **Home** so Notion stays a light hub—**Linear owns the backlog**; do not duplicate issue lists here.
 
-- **Linear:** [https://linear.app/invincib1e](https://linear.app/invincib1e) (your team)
-- **GitHub:** [https://github.com/Aurora-091/venus-ai](https://github.com/Aurora-091/venus-ai)
-- **Docs (read-only on GitHub):** [docs/README.md on `main`](https://github.com/Aurora-091/venus-ai/blob/main/docs/README.md)
-- **Vercel:** your Vercel project dashboard URL
-- **Supabase:** your Supabase project dashboard URL
-- **Production app:** your live URL when you have one
+- **Work:** [Linear (Invincib1e)](https://linear.app/invincib1e) — issues, specs, status (no backlog mirror in Notion)
+- **Code + docs:** [GitHub repo](https://github.com/Aurora-091/venus-ai) and [Docs hub on `main`](https://github.com/Aurora-091/venus-ai/blob/main/docs/README.md) — versioned setup, env names, integrations
+- **Ops:** Your **Vercel** project, **Supabase** dashboard, and **production app** URL (one line each or a single “Dashboards” sub-page if you need more links)
 
 ---
 
@@ -87,7 +84,7 @@ In **Notion Settings → Connections**, add **Linear** if available. Then you ca
 ## Checklist
 
 - [-] **Aurora** parent page exists with **Home** + **Engineering** + **Runbooks** + **Knowledge**
-- [-] **Home** has links to Linear, GitHub, Vercel, Supabase, prod URL
+- [-] **Home** has the three hub bullets (Linear, GitHub + docs hub, ops dashboards / prod URL)
 - [ ] At least **collaboration** + **workflow** content is summarized or linked
 - [-] Team agrees: **Linear** = tasks, **Notion** = narrative, **GitHub** = code
 - [-] Optional: [Notion `main` push log](integrations/notion-github-automation.md) (GitHub Actions + database)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the primary onboarding doc so new developers and agents can run Aurora without guessing env vars, ports, or which `npm` commands work on Linux/macOS.

## Changes

- **`docs/getting-started.md`**: Node **24.x** (matches CI), full tables for `frontend/.env` and `backend/.env` from the checked-in examples, fixed ports (**5682** / **5000**), Vite proxy behavior, cross-platform commands to run frontend + backend (avoids the Windows-only root `npm run dev`), `backend/supabase_schema.sql` for Supabase setup, and a note that root `db:*` scripts are not wired in `backend/package.json` today.
- **`docs/notion-aurora-hub.md`**: **Home** hub limited to **three bullets** so Notion does not duplicate the Linear backlog.

No product code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f03677bc-c593-4008-a4f3-1309cf5d3ace"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f03677bc-c593-4008-a4f3-1309cf5d3ace"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

