### PR TITLE
Phase 2: golden path data — agent settings, calendar status, load errors

### DIFF
--- a/backend/migrations/20260503_tenant_settings.sql
+++ b/backend/migrations/20260503_tenant_settings.sql
@@ -1,0 +1,4 @@
+-- Add settings JSONB for tenant-scoped app config (Agent Studio, integrations).
+-- Run in Supabase SQL editor if the table was created from an older schema.
+alter table public.tenants
+  add column if not exists settings jsonb not null default '{}';

--- a/backend/server/routes/api.js
+++ b/backend/server/routes/api.js
@@ -19,11 +19,16 @@ import { requireAuth } from "../middleware/auth.js";
 export function createApiRouter(io) {
   const router = Router();
 
-  const oauth2Client = new google.auth.OAuth2(
-    process.env.GOOGLE_CLIENT_ID,
-    process.env.GOOGLE_CLIENT_SECRET,
-    "http://localhost:5000/api/auth/google/callback"
-  );
+  const oauthConfigured =
+    Boolean(process.env.GOOGLE_CLIENT_ID) && Boolean(process.env.GOOGLE_CLIENT_SECRET);
+
+  const oauth2Client = oauthConfigured
+    ? new google.auth.OAuth2(
+        process.env.GOOGLE_CLIENT_ID,
+        process.env.GOOGLE_CLIENT_SECRET,
+        "http://localhost:5000/api/auth/google/callback"
+      )
+    : null;
 
   router.get("/ping", (_req, res) => {
     res.json({ ok: true, stack: "mern", ts: Date.now() });
@@ -406,21 +411,46 @@ export function createApiRouter(io) {
   });
 
   router.get("/tenants/:id/calendar/auth-url", (_req, res) => {
+    if (!oauth2Client) {
+      return res.status(503).json({
+        url: null,
+        configured: false,
+        error:
+          "Google OAuth is not configured. Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET in backend/.env.",
+      });
+    }
     const url = oauth2Client.generateAuthUrl({
       access_type: "offline",
       prompt: "consent", // Force to always get a refresh_token
       scope: ["https://www.googleapis.com/auth/calendar.events", "https://www.googleapis.com/auth/calendar.readonly"],
       state: _req.params.id,
     });
-    res.json({ url });
+    res.json({ url, configured: true });
   });
 
   router.get("/tenants/:id/calendar/status", async (req, res) => {
+    if (!oauthConfigured) {
+      return res.json({
+        connected: false,
+        calendarId: "primary",
+        oauthConfigured: false,
+        message:
+          "Google Calendar OAuth is not configured on the server (missing GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET).",
+      });
+    }
     const integration = await getIntegration(req.params.id, "google_calendar");
     if (integration?.connected) {
-      res.json({ connected: true, calendarId: integration.calendar_id });
+      res.json({
+        connected: true,
+        calendarId: integration.calendar_id,
+        oauthConfigured: true,
+      });
     } else {
-      res.json({ connected: false, calendarId: "primary" });
+      res.json({
+        connected: false,
+        calendarId: "primary",
+        oauthConfigured: true,
+      });
     }
   });
 

--- a/backend/server/services/repositories.js
+++ b/backend/server/services/repositories.js
@@ -18,22 +18,33 @@ export async function findUserById(id) {
 export async function listTenants(user) {
   if (user?.role === "super_admin") {
     const { data } = await supabase.from('tenants').select('*').order('created_at', { ascending: false });
-    return data || [];
+    return (data || []).map(formatTenant);
   }
   if (user?.tenantId) {
     const { data } = await supabase.from('tenants').select('*').eq('id', user.tenantId);
-    return data || [];
+    return (data || []).map(formatTenant);
   }
   return [];
 }
 
 export async function findTenantById(id) {
   const { data } = await supabase.from('tenants').select('*').eq('id', id).single();
-  return data || null;
+  return data ? formatTenant(data) : null;
 }
 
 export async function createTenant(payload, user) {
   const id = crypto.randomUUID();
+  const ext = payload.external_integrations;
+  const settings =
+    ext && (ext.shopifyUrl || ext.shopifyToken)
+      ? {
+          shopify: {
+            storeUrl: ext.shopifyUrl || "",
+            adminToken: ext.shopifyToken || "",
+          },
+        }
+      : {};
+
   const tenant = {
     id,
     name: payload.name,
@@ -44,6 +55,7 @@ export async function createTenant(payload, user) {
     agent_greeting: buildGreeting(payload.vertical, payload.agentName || "Aria", payload.name),
     status: "active",
     plan: "starter",
+    settings,
   };
 
   const { data: created, error } = await supabase.from('tenants').insert(tenant).select('*').single();
@@ -63,14 +75,46 @@ export async function createTenant(payload, user) {
 }
 
 export async function updateTenant(id, payload) {
-  // Map JS casing to DB casing before update (if needed)
+  const existing = await findTenantById(id);
+  if (!existing) return null;
+
   const updates = {};
-  if (payload.name) updates.name = payload.name;
-  if (payload.timezone) updates.timezone = payload.timezone;
-  if (payload.agentId) updates.agent_id = payload.agentId;
-  if (payload.phoneNumberId) updates.phone_number_id = payload.phoneNumberId;
-  if (payload.phoneNumber) updates.phone_number = payload.phoneNumber;
-  if (payload.agentStatus) updates.agent_status = payload.agentStatus;
+  if (payload.name !== undefined) updates.name = payload.name;
+  if (payload.timezone !== undefined) updates.timezone = payload.timezone;
+  if (payload.agentId !== undefined) updates.agent_id = payload.agentId;
+  if (payload.phoneNumberId !== undefined) updates.phone_number_id = payload.phoneNumberId;
+  if (payload.phoneNumber !== undefined) updates.phone_number = payload.phoneNumber;
+  if (payload.agentStatus !== undefined) updates.agent_status = payload.agentStatus;
+
+  if (payload.agentName !== undefined) updates.agent_name = payload.agentName;
+  if (payload.agentLanguage !== undefined) updates.agent_language = payload.agentLanguage;
+  if (payload.agentVoiceId !== undefined) updates.agent_voice_id = payload.agentVoiceId;
+  if (payload.agentGreeting !== undefined) updates.agent_greeting = payload.agentGreeting;
+  if (payload.businessHoursStart !== undefined) {
+    updates.business_hours_start = payload.businessHoursStart;
+  }
+  if (payload.businessHoursEnd !== undefined) {
+    updates.business_hours_end = payload.businessHoursEnd;
+  }
+
+  if (payload.metadata?.shopify !== undefined) {
+    const { data: rawRow } = await supabase
+      .from('tenants')
+      .select('settings')
+      .eq('id', id)
+      .single();
+    const prev =
+      rawRow?.settings && typeof rawRow.settings === 'object' ? rawRow.settings : {};
+    const prevShopify = prev.shopify && typeof prev.shopify === 'object' ? prev.shopify : {};
+    const nextShopify = payload.metadata.shopify;
+    updates.settings = {
+      ...prev,
+      shopify: {
+        storeUrl: nextShopify.storeUrl ?? prevShopify.storeUrl ?? "",
+        adminToken: nextShopify.adminToken ?? prevShopify.adminToken ?? "",
+      },
+    };
+  }
 
   const { data, error } = await supabase.from('tenants').update(updates).eq('id', id).select('*').single();
   if (error || !data) return null;
@@ -164,8 +208,11 @@ function buildGreeting(vertical, agentName, businessName) {
 
 function formatTenant(t) {
   if (!t) return null;
+  const settings = t.settings && typeof t.settings === "object" ? t.settings : {};
+  const shopify = settings.shopify && typeof settings.shopify === "object" ? settings.shopify : {};
+  const { settings: _s, ...rest } = t;
   return {
-    ...t,
+    ...rest,
     agentId: t.agent_id,
     phoneNumberId: t.phone_number_id,
     phoneNumber: t.phone_number,
@@ -179,6 +226,13 @@ function formatTenant(t) {
     whitelabelEnabled: t.whitelabel_enabled,
     whitelabelBrand: t.whitelabel_brand,
     createdAt: t.created_at,
+    metadata: {
+      shopify: {
+        storeUrl: shopify.storeUrl || "",
+        adminToken: shopify.adminToken || "",
+      },
+    },
+    shopifyConnected: Boolean(shopify.storeUrl && shopify.adminToken),
   };
 }
 

--- a/backend/supabase_schema.sql
+++ b/backend/supabase_schema.sql
@@ -58,6 +58,8 @@ create table if not exists tenants (
   -- White-label
   whitelabel_enabled boolean default false,
   whitelabel_brand text default '',
+  -- Extensible key-value config (e.g. Shopify, custom fields) for Agent Studio
+  settings jsonb not null default '{}',
   created_at timestamptz not null default now()
 );
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,6 +43,8 @@ npm run dev
 
 Use when you need `/api`, WebSockets, or server-side integrations (Twilio, ElevenLabs, Google, etc.).
 
+New Supabase projects bootstrapped from this repo should run `backend/migrations/20260503_tenant_settings.sql` (or use the updated `backend/supabase_schema.sql`) so the `tenants.settings` column exists for Shopify keys and other Agent Studio JSON config.
+
 ```bash
 cd backend
 npm ci

--- a/frontend/src/pages/dashboard/agent.tsx
+++ b/frontend/src/pages/dashboard/agent.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'wouter';
 import { api } from '../../lib/api';
-import { Copy, Plus, Boxes, Zap, Check, Phone } from 'lucide-react'; // Assume lucide-react is installed, if not we'll use placeholder SVGs or simple text. Wait, venus-ai likely has lucide-react. Standard. Let's use simple SVGs to be safe if not sure.
 
 interface Props {
   tenant?: any;
@@ -416,9 +416,12 @@ export default function AgentStudio({ tenant, onTenantUpdate }: Props) {
                       </p>
                     </div>
                   </div>
-                  <button className="bg-blue-600 hover:bg-blue-500 text-white text-xs px-4 py-2 rounded-lg transition-colors w-full">
-                    Connect Google Calendar
-                  </button>
+                  <Link
+                    href="/dashboard/integrations"
+                    className="block w-full text-center bg-blue-600 hover:bg-blue-500 text-white text-xs px-4 py-2.5 rounded-lg transition-colors font-medium"
+                  >
+                    Open Integrations to connect
+                  </Link>
                 </div>
               )}
 

--- a/frontend/src/pages/dashboard/bookings.tsx
+++ b/frontend/src/pages/dashboard/bookings.tsx
@@ -16,11 +16,13 @@ export default function Bookings({ tenant }: Props) {
   const [bookings, setBookings] = useState<any[]>([]);
   const [orders, setOrders] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [tab, setTab] = useState<'bookings' | 'orders'>('bookings');
 
   useEffect(() => {
     if (!tenant?.id) return;
     setLoading(true);
+    setLoadError(null);
     const ps: Promise<any>[] = [api.get(`/tenants/${tenant.id}/bookings`)];
     if (tenant.vertical === 'ecommerce') {
       ps.push(api.get(`/tenants/${tenant.id}/orders`));
@@ -30,7 +32,13 @@ export default function Bookings({ tenant }: Props) {
         setBookings(b.bookings || []);
         setOrders(o?.orders || []);
       })
-      .catch(() => {})
+      .catch((e: Error) => {
+        setLoadError(
+          e.message?.includes('Failed to fetch')
+            ? 'Could not load bookings — is the API running on port 5000?'
+            : e.message
+        );
+      })
       .finally(() => setLoading(false));
   }, [tenant?.id]);
 
@@ -57,6 +65,12 @@ export default function Bookings({ tenant }: Props) {
           Appointments and reservations made via your voice agent
         </p>
       </div>
+
+      {loadError && (
+        <div className="mb-5 text-sm px-4 py-3 rounded-xl bg-red-500/10 text-red-300 border border-red-500/20">
+          {loadError}
+        </div>
+      )}
 
       {/* Tabs — only for ecom */}
       {isEcom && (

--- a/frontend/src/pages/dashboard/calls.tsx
+++ b/frontend/src/pages/dashboard/calls.tsx
@@ -36,6 +36,7 @@ export default function Calls({ tenant }: Props) {
   const [outboundNumber, setOutboundNumber] = useState('');
   const [calling, setCalling] = useState(false);
   const [callMsg, setCallMsg] = useState('');
+  const [loadError, setLoadError] = useState<string | null>(null);
   const hasRealAgent =
     !!tenant?.agentId && !tenant.agentId.startsWith('local-');
   const hasRealPhoneNumber =
@@ -44,11 +45,18 @@ export default function Calls({ tenant }: Props) {
   useEffect(() => {
     if (!tenant?.id) return;
     setLoading(true);
+    setLoadError(null);
     Promise.all([
       api
         .get(`/tenants/${tenant.id}/calls`)
         .then((r) => setLocalCalls(r.calls || []))
-        .catch(() => {}),
+        .catch((e: Error) => {
+          setLoadError(
+            e.message?.includes('Failed to fetch')
+              ? 'API unreachable — run the backend on port 5000 for live call data.'
+              : e.message
+          );
+        }),
       hasRealAgent
         ? api
             .get(`/tenants/${tenant.id}/conversations`)
@@ -143,6 +151,12 @@ export default function Calls({ tenant }: Props) {
           </div>
         )}
       </div>
+
+      {loadError && (
+        <div className="mb-4 text-xs px-4 py-2.5 rounded-xl bg-red-500/10 text-red-400 border border-red-500/20">
+          {loadError}
+        </div>
+      )}
 
       {callMsg && (
         <div

--- a/frontend/src/pages/dashboard/integrations.tsx
+++ b/frontend/src/pages/dashboard/integrations.tsx
@@ -10,6 +10,8 @@ export default function Integrations({ tenant }: Props) {
   const [calStatus, setCalStatus] = useState<{
     connected: boolean;
     calendarId?: string;
+    oauthConfigured?: boolean;
+    message?: string;
   } | null>(null);
   const [sheetsStatus, setSheetsStatus] = useState<{
     connected: boolean;
@@ -31,21 +33,30 @@ export default function Integrations({ tenant }: Props) {
     setTimeout(() => setMsg(null), 5000);
   };
 
+  const [calLoadError, setCalLoadError] = useState<string | null>(null);
+
   const loadStatus = async () => {
     if (!tenant?.id) return;
     setLoading(true);
+    setCalLoadError(null);
     try {
-      const [cal, sheets] = await Promise.all([
-        api
-          .get(`/tenants/${tenant.id}/calendar/status`)
-          .catch(() => ({ connected: false })),
-        api
-          .get(`/tenants/${tenant.id}/sheets/status`)
-          .catch(() => ({ connected: false })),
-      ]);
+      const cal = await api.get(`/tenants/${tenant.id}/calendar/status`);
       setCalStatus(cal);
+    } catch (e: unknown) {
+      const msg =
+        e instanceof Error && e.message?.includes('Failed to fetch')
+          ? 'Cannot reach the API — start the backend on port 5000 for integration status.'
+          : e instanceof Error
+            ? e.message
+            : 'Failed to load calendar status.';
+      setCalLoadError(msg);
+    }
+    try {
+      const sheets = await api.get(`/tenants/${tenant.id}/sheets/status`);
       setSheetsStatus(sheets);
-    } catch {}
+    } catch {
+      setSheetsStatus({ connected: false });
+    }
     setLoading(false);
   };
 
@@ -60,7 +71,11 @@ export default function Integrations({ tenant }: Props) {
     try {
       const r = await api.get(`/tenants/${tenant.id}/calendar/auth-url`);
       if (!r.url) {
-        showMsg('Could not get auth URL', false);
+        showMsg(
+          r.error ||
+            'Calendar OAuth is not available. Configure GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET in backend/.env.',
+          false
+        );
         return;
       }
       const popup = window.open(
@@ -288,6 +303,12 @@ export default function Integrations({ tenant }: Props) {
         </div>
       )}
 
+      {calLoadError && (
+        <div className="text-xs px-4 py-3 rounded-xl bg-red-500/10 text-red-400 border border-red-500/20">
+          {calLoadError}
+        </div>
+      )}
+
       {/* ── Tier 1 Core Integrations ── */}
       <div className="text-xs font-medium text-[#475569] uppercase tracking-wide mb-3">
         Tier 1 Integrations
@@ -332,7 +353,10 @@ export default function Integrations({ tenant }: Props) {
         connectedDetail={
           calStatus?.connected
             ? 'Calendar connected — agent uses real availability'
-            : undefined
+            : calStatus?.oauthConfigured === false
+              ? calStatus.message ||
+                'OAuth not configured on the server — add Google credentials to backend/.env.'
+              : undefined
         }
       />
 

--- a/frontend/src/pages/dashboard/overview.tsx
+++ b/frontend/src/pages/dashboard/overview.tsx
@@ -67,10 +67,12 @@ export default function Overview({ tenant }: Props) {
   const [analytics, setAnalytics] = useState<Analytics | null>(null);
   const [calls, setCalls] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!tenant?.id) return;
     setLoading(true);
+    setLoadError(null);
     Promise.all([
       api.get(`/tenants/${tenant.id}/analytics`),
       api.get(`/tenants/${tenant.id}/calls`),
@@ -79,7 +81,15 @@ export default function Overview({ tenant }: Props) {
         setAnalytics(a);
         setCalls((c.calls || []).slice(0, 5));
       })
-      .catch(() => {})
+      .catch((e: Error) => {
+        setLoadError(
+          e.message?.includes('Failed to fetch')
+            ? 'Could not reach the API. Start the backend on port 5000 (see docs/getting-started.md) or check your network.'
+            : e.message || 'Failed to load dashboard data.'
+        );
+        setAnalytics(null);
+        setCalls([]);
+      })
       .finally(() => setLoading(false));
   }, [tenant?.id]);
 
@@ -122,6 +132,12 @@ export default function Overview({ tenant }: Props) {
           <span className={`${verticalColor}`}>{tenant.vertical}</span>
         </p>
       </div>
+
+      {loadError && (
+        <div className="mb-5 bg-red-500/10 border border-red-500/30 rounded-xl px-4 py-3 text-sm text-red-300">
+          {loadError}
+        </div>
+      )}
 
       {/* Agent status banner */}
       {tenant.agentStatus !== 'active' && (

--- a/frontend/src/pages/onboarding.tsx
+++ b/frontend/src/pages/onboarding.tsx
@@ -380,6 +380,13 @@ export default function Onboarding() {
                         const res = await api.get(
                           `/tenants/${tenantId}/calendar/auth-url`
                         );
+                        if (!res.url) {
+                          alert(
+                            res.error ||
+                              'Google OAuth is not configured on the server. Add GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET to backend/.env, or skip for now.'
+                          );
+                          return;
+                        }
                         window.open(res.url, '_blank', 'width=500,height=600');
                         window.addEventListener(
                           'message',
@@ -389,11 +396,14 @@ export default function Onboarding() {
                           },
                           { once: true }
                         );
-                      } catch {
+                      } catch (e: unknown) {
+                        const msg =
+                          e instanceof Error ? e.message : 'Request failed';
                         alert(
-                          'Google OAuth not configured — skipping in demo mode'
+                          msg.includes('503')
+                            ? 'Google OAuth is not configured. Add credentials to backend/.env or skip below.'
+                            : msg
                         );
-                        setStep(4);
                       }
                     }}
                     className="w-full flex items-center justify-center gap-2 bg-white hover:bg-gray-200 transition-colors text-black font-semibold py-3 rounded-md text-sm"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Delivers **Phase 2 (roadmap)** improvements: data surfaces no longer fail silently, Agent Studio fields persist to Supabase, and Google Calendar integration state is explicit when OAuth is missing or the API is down.

## Linear

**Issue:** `INV-___` (link the matching epic or task when created)

## Type of change

- [x] New feature
- [x] Bug fix
- [x] Documentation

## What changed

- **Backend:** `tenants.settings` JSONB (schema + one-line migration) for Shopify keys from onboarding / Agent Studio; `PATCH /tenants/:id` now maps `agentName`, voice, greeting, business hours, and merges `metadata.shopify` into `settings`.
- **API:** Calendar endpoints return `oauthConfigured` and a **message** when `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` are unset; `GET /calendar/auth-url` returns **503** with JSON instead of a blank URL when OAuth is not configured.
- **Frontend:** Overview, Call Logs, Bookings, and Integrations show **actionable errors** when the API is unreachable or requests fail; Integrations surfaces **not configured** vs **disconnected** for Calendar; Agent Studio links to Integrations for Calendar OAuth; onboarding explains OAuth/config failures instead of silently skipping.

## Database

Existing projects should run `backend/migrations/20260503_tenant_settings.sql` (documented in `docs/getting-started.md`).

## Verification

- `npm run type-check` and `npm run lint` in `frontend/` (warnings only, pre-existing in some files)
- `node --check` on updated backend files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3d89352-01a4-4652-8433-c0f06ffe67ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3d89352-01a4-4652-8433-c0f06ffe67ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

