### PR TITLE
Vision Phase 2 (Core Voice Engine): Realtime call metrics, routing hooks, tenant fix

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,3 +14,9 @@ TWILIO_PHONE_NUMBER=
 # Optional Google integrations.
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+
+# Vision Phase 2 — webhooks
+# Optional shared secret for POST /api/twilio/resolve-inbound (header X-VoiceOS-Secret)
+TWILIO_WEBHOOK_SECRET=
+# Bearer token for POST /api/internal/voice/call-event (ingest call logs from bridges)
+INTERNAL_WEBHOOK_SECRET=

--- a/backend/migrations/20260503_call_logs_realtime_rls.sql
+++ b/backend/migrations/20260503_call_logs_realtime_rls.sql
@@ -1,0 +1,16 @@
+-- Vision Phase 2: dashboard Supabase Realtime on call_logs (tenant-scoped SELECT)
+-- Run after deploying backend that relies on JWT tenant claims.
+
+-- Allow authenticated users to read call_logs only for their workspace tenant.
+drop policy if exists "Tenant users read own call_logs" on public.call_logs;
+create policy "Tenant users read own call_logs"
+  on public.call_logs
+  for select
+  to authenticated
+  using (
+    tenant_id is not null
+    and tenant_id::text = coalesce((auth.jwt() -> 'user_metadata' ->> 'tenantId'), '')
+  );
+
+-- Enable Realtime for this table in Supabase: Dashboard → Database → Replication
+-- → enable `call_logs` for the `supabase_realtime` publication (if not already on).

--- a/backend/server/routes/api.js
+++ b/backend/server/routes/api.js
@@ -1,15 +1,18 @@
 import { Router } from "express";
+import express from "express";
 import { google } from "googleapis";
 import {
   createCallLog,
   createTenant,
   deleteTenant,
   findTenantById,
+  findTenantIdByPhoneNumber,
   getAnalytics,
   listBookings,
   listCalls,
   listOrders,
   listTenants,
+  normalizePhoneForLookup,
   updateTenant,
   upsertIntegration,
   getIntegration,
@@ -19,14 +22,103 @@ import { requireAuth } from "../middleware/auth.js";
 export function createApiRouter(io) {
   const router = Router();
 
-  const oauth2Client = new google.auth.OAuth2(
-    process.env.GOOGLE_CLIENT_ID,
-    process.env.GOOGLE_CLIENT_SECRET,
-    "http://localhost:5000/api/auth/google/callback"
-  );
+  const oauthConfigured =
+    Boolean(process.env.GOOGLE_CLIENT_ID) && Boolean(process.env.GOOGLE_CLIENT_SECRET);
+
+  const oauth2Client = oauthConfigured
+    ? new google.auth.OAuth2(
+        process.env.GOOGLE_CLIENT_ID,
+        process.env.GOOGLE_CLIENT_SECRET,
+        "http://localhost:5000/api/auth/google/callback"
+      )
+    : null;
+
+  function getCalendarClientForTenant(tenantId) {
+    return getIntegration(tenantId, "google_calendar").then((integration) => {
+      if (!oauth2Client || !integration?.connected || !integration.refresh_token) {
+        return null;
+      }
+      oauth2Client.setCredentials({ refresh_token: integration.refresh_token });
+      return google.calendar({ version: "v3", auth: oauth2Client });
+    });
+  }
 
   router.get("/ping", (_req, res) => {
     res.json({ ok: true, stack: "mern", ts: Date.now() });
+  });
+
+  /**
+   * Vision Phase 2 — map inbound Twilio number → tenant (configure as Twilio HTTP webhook / Studio HTTP request).
+   * Optional: set TWILIO_WEBHOOK_SECRET and send header X-VoiceOS-Secret.
+   */
+  router.post(
+    "/twilio/resolve-inbound",
+    express.urlencoded({ extended: true }),
+    (req, res, next) => {
+      const secret = process.env.TWILIO_WEBHOOK_SECRET;
+      if (secret && req.headers["x-voiceos-secret"] !== secret) {
+        return res.status(401).json({ error: "Invalid webhook secret" });
+      }
+      next();
+    },
+    async (req, res) => {
+      const to = req.body?.To || req.body?.Called || req.query?.to || "";
+      const from = req.body?.From || req.body?.Caller || "";
+      const tenantId = await findTenantIdByPhoneNumber(String(to));
+      res.json({
+        tenant_id: tenantId,
+        matched_to: to,
+        from,
+        digits_to: normalizePhoneForLookup(String(to)),
+      });
+    }
+  );
+
+  /**
+   * Internal webhook (ElevenLabs post-call, custom bridges). Inserts call_logs and notifies Socket.IO room.
+   * Set INTERNAL_WEBHOOK_SECRET and send Authorization: Bearer <secret>.
+   */
+  router.post("/internal/voice/call-event", async (req, res) => {
+    const expected = process.env.INTERNAL_WEBHOOK_SECRET;
+    const auth = req.headers.authorization || "";
+    const token = auth.startsWith("Bearer ") ? auth.slice(7) : "";
+    if (expected && token !== expected) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+    const {
+      tenant_id: tenantId,
+      tenantId: tid,
+      caller_number: callerNumber,
+      callerNumber: cn,
+      direction = "inbound",
+      duration_seconds: durationSeconds,
+      durationSeconds: ds,
+      outcome = "completed",
+      summary = "",
+      conversation_id: conversationId,
+      conversationId: cid,
+    } = req.body || {};
+    const tId = tenantId || tid;
+    if (!tId) return res.status(400).json({ error: "tenant_id required" });
+
+    try {
+      const call = await createCallLog(
+        {
+          tenantId: tId,
+          callerNumber: callerNumber || cn || "",
+          direction,
+          durationSeconds: Number(durationSeconds ?? ds ?? 0) || 0,
+          outcome,
+          summary: summary || "",
+          conversationId: conversationId || cid || "",
+        },
+        io
+      );
+      res.status(201).json({ success: true, call });
+    } catch (e) {
+      console.error("[voice/call-event]", e);
+      res.status(500).json({ error: String(e?.message || e) });
+    }
   });
 
   // Open callbacks
@@ -34,6 +126,9 @@ export function createApiRouter(io) {
     const code = req.query.code;
     const tenantId = req.query.state;
     if (!code || !tenantId) return res.status(400).send("Invalid callback");
+    if (!oauth2Client) {
+      return res.status(503).send("Google OAuth is not configured on this server.");
+    }
 
     try {
       const { tokens } = await oauth2Client.getToken(code);
@@ -213,12 +308,14 @@ export function createApiRouter(io) {
         return res.json({ result: "Google Calendar is not connected. I cannot check availability right now." });
       }
 
-      oauth2Client.setCredentials({ refresh_token: integration.refresh_token });
-      const calendar = google.calendar({ version: "v3", auth: oauth2Client });
-      
+      const calendar = await getCalendarClientForTenant(req.params.id);
+      if (!calendar) {
+        return res.json({ result: "Google Calendar OAuth is not configured on the server." });
+      }
+
       const timeMin = new Date(`${requestedDate}T00:00:00.000Z`);
       const timeMax = new Date(`${requestedDate}T23:59:59.999Z`);
-      
+
       const response = await calendar.events.list({
         calendarId: integration.calendar_id || "primary",
         timeMin: timeMin.toISOString(),
@@ -260,13 +357,15 @@ export function createApiRouter(io) {
         return res.json({ result: "Google Calendar is not connected. I cannot book the appointment right now." });
       }
 
-      oauth2Client.setCredentials({ refresh_token: integration.refresh_token });
-      const calendar = google.calendar({ version: "v3", auth: oauth2Client });
+      const calendar = await getCalendarClientForTenant(req.params.id);
+      if (!calendar) {
+        return res.json({ result: "Google Calendar OAuth is not configured on the server." });
+      }
 
       const startTime = new Date(slot);
       const endTime = new Date(startTime.getTime() + 60 * 60 * 1000); // 1 hour duration
 
-      const event = await calendar.events.insert({
+      await calendar.events.insert({
         calendarId: integration.calendar_id || "primary",
         requestBody: {
           summary: `${service} - ${callerName}`,
@@ -336,7 +435,7 @@ export function createApiRouter(io) {
       outcome: "initiated",
       summary: "Outbound call initiated through ElevenLabs",
       conversationId: data.conversation_id || "",
-    });
+    }, io);
     io.to(req.params.id).emit("call:created", call);
     res.status(202).json({ success: true, conversation_id: data.conversation_id || "", call });
   });
@@ -406,21 +505,46 @@ export function createApiRouter(io) {
   });
 
   router.get("/tenants/:id/calendar/auth-url", (_req, res) => {
+    if (!oauth2Client) {
+      return res.status(503).json({
+        url: null,
+        configured: false,
+        error:
+          "Google OAuth is not configured. Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET in backend/.env.",
+      });
+    }
     const url = oauth2Client.generateAuthUrl({
       access_type: "offline",
       prompt: "consent", // Force to always get a refresh_token
       scope: ["https://www.googleapis.com/auth/calendar.events", "https://www.googleapis.com/auth/calendar.readonly"],
       state: _req.params.id,
     });
-    res.json({ url });
+    res.json({ url, configured: true });
   });
 
   router.get("/tenants/:id/calendar/status", async (req, res) => {
+    if (!oauthConfigured) {
+      return res.json({
+        connected: false,
+        calendarId: "primary",
+        oauthConfigured: false,
+        message:
+          "Google Calendar OAuth is not configured on the server (missing GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET).",
+      });
+    }
     const integration = await getIntegration(req.params.id, "google_calendar");
     if (integration?.connected) {
-      res.json({ connected: true, calendarId: integration.calendar_id });
+      res.json({
+        connected: true,
+        calendarId: integration.calendar_id,
+        oauthConfigured: true,
+      });
     } else {
-      res.json({ connected: false, calendarId: "primary" });
+      res.json({
+        connected: false,
+        calendarId: "primary",
+        oauthConfigured: true,
+      });
     }
   });
 

--- a/backend/server/routes/api.js
+++ b/backend/server/routes/api.js
@@ -436,7 +436,6 @@ export function createApiRouter(io) {
       summary: "Outbound call initiated through ElevenLabs",
       conversationId: data.conversation_id || "",
     }, io);
-    io.to(req.params.id).emit("call:created", call);
     res.status(202).json({ success: true, conversation_id: data.conversation_id || "", call });
   });
 

--- a/backend/server/services/repositories.js
+++ b/backend/server/services/repositories.js
@@ -18,18 +18,50 @@ export async function findUserById(id) {
 export async function listTenants(user) {
   if (user?.role === "super_admin") {
     const { data } = await supabase.from('tenants').select('*').order('created_at', { ascending: false });
-    return data || [];
+    return (data || []).map(formatTenant);
   }
   if (user?.tenantId) {
     const { data } = await supabase.from('tenants').select('*').eq('id', user.tenantId);
-    return data || [];
+    return (data || []).map(formatTenant);
   }
   return [];
 }
 
+/** Normalize to E.164-ish digits for lookup (+ prefix optional). */
+export function normalizePhoneForLookup(raw) {
+  if (!raw || typeof raw !== "string") return "";
+  let s = raw.trim().replace(/\s/g, "");
+  if (s.startsWith("+")) s = s.slice(1);
+  return s.replace(/\D/g, "");
+}
+
+/**
+ * Map inbound Twilio / CLI number to tenant (Vision Phase 2 — number → agent).
+ * Matches tenants.phone_number using digit-normalized equality.
+ */
+export async function findTenantIdByPhoneNumber(incomingNumber) {
+  const digits = normalizePhoneForLookup(incomingNumber);
+  if (!digits || digits.length < 10) return null;
+
+  const { data: tenantsRows } = await supabase
+    .from("tenants")
+    .select("id, phone_number")
+    .not("phone_number", "eq", "");
+
+  if (!tenantsRows?.length) return null;
+
+  for (const row of tenantsRows) {
+    const rowDigits = normalizePhoneForLookup(row.phone_number || "");
+    if (rowDigits && (rowDigits === digits || rowDigits.endsWith(digits) || digits.endsWith(rowDigits))) {
+      return row.id;
+    }
+  }
+  return null;
+}
+
 export async function findTenantById(id) {
   const { data } = await supabase.from('tenants').select('*').eq('id', id).single();
-  return data || null;
+  return data ? formatTenant(data) : null;
 }
 
 export async function createTenant(payload, user) {
@@ -63,14 +95,23 @@ export async function createTenant(payload, user) {
 }
 
 export async function updateTenant(id, payload) {
-  // Map JS casing to DB casing before update (if needed)
   const updates = {};
-  if (payload.name) updates.name = payload.name;
-  if (payload.timezone) updates.timezone = payload.timezone;
-  if (payload.agentId) updates.agent_id = payload.agentId;
-  if (payload.phoneNumberId) updates.phone_number_id = payload.phoneNumberId;
-  if (payload.phoneNumber) updates.phone_number = payload.phoneNumber;
-  if (payload.agentStatus) updates.agent_status = payload.agentStatus;
+  if (payload.name !== undefined) updates.name = payload.name;
+  if (payload.timezone !== undefined) updates.timezone = payload.timezone;
+  if (payload.agentId !== undefined) updates.agent_id = payload.agentId;
+  if (payload.phoneNumberId !== undefined) updates.phone_number_id = payload.phoneNumberId;
+  if (payload.phoneNumber !== undefined) updates.phone_number = payload.phoneNumber;
+  if (payload.agentStatus !== undefined) updates.agent_status = payload.agentStatus;
+  if (payload.agentName !== undefined) updates.agent_name = payload.agentName;
+  if (payload.agentLanguage !== undefined) updates.agent_language = payload.agentLanguage;
+  if (payload.agentVoiceId !== undefined) updates.agent_voice_id = payload.agentVoiceId;
+  if (payload.agentGreeting !== undefined) updates.agent_greeting = payload.agentGreeting;
+  if (payload.businessHoursStart !== undefined) {
+    updates.business_hours_start = payload.businessHoursStart;
+  }
+  if (payload.businessHoursEnd !== undefined) {
+    updates.business_hours_end = payload.businessHoursEnd;
+  }
 
   const { data, error } = await supabase.from('tenants').update(updates).eq('id', id).select('*').single();
   if (error || !data) return null;
@@ -96,7 +137,7 @@ export async function listOrders(tenantId) {
   return (data || []).map(formatOrder);
 }
 
-export async function createCallLog(payload) {
+export async function createCallLog(payload, io = null) {
   const dbPayload = {
     tenant_id: payload.tenantId,
     caller_number: payload.callerNumber,
@@ -108,7 +149,15 @@ export async function createCallLog(payload) {
   };
   const { data, error } = await supabase.from('call_logs').insert(dbPayload).select('*').single();
   if (error) throw new Error(error.message);
-  return formatCallLog(data);
+  const formatted = formatCallLog(data);
+  if (io?.to) {
+    try {
+      io.to(payload.tenantId).emit("call:created", formatted);
+    } catch {
+      /* ignore emit failures */
+    }
+  }
+  return formatted;
 }
 
 export async function getAnalytics(tenantId) {
@@ -164,8 +213,24 @@ function buildGreeting(vertical, agentName, businessName) {
 
 function formatTenant(t) {
   if (!t) return null;
+  const {
+    agent_id: _aid,
+    phone_number_id: _pid,
+    phone_number: _pn,
+    agent_status: _as,
+    agent_name: _an,
+    agent_language: _al,
+    agent_voice_id: _avi,
+    agent_greeting: _ag,
+    business_hours_start: _bhs,
+    business_hours_end: _bhe,
+    whitelabel_enabled: _we,
+    whitelabel_brand: _wb,
+    created_at: _ca,
+    ...rest
+  } = t;
   return {
-    ...t,
+    ...rest,
     agentId: t.agent_id,
     phoneNumberId: t.phone_number_id,
     phoneNumber: t.phone_number,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -63,8 +63,10 @@ Edit `backend/.env`:
 | `TWILIO_PHONE_NUMBER` | |
 | `GOOGLE_CLIENT_ID` | Optional Google integrations |
 | `GOOGLE_CLIENT_SECRET` | |
+| `TWILIO_WEBHOOK_SECRET` | Optional; `POST /api/twilio/resolve-inbound` accepts header `X-VoiceOS-Secret` when set |
+| `INTERNAL_WEBHOOK_SECRET` | Optional; `Authorization: Bearer …` for `POST /api/internal/voice/call-event` |
 
-```bash
+**Vision Phase 2 (live analytics):** Run `backend/migrations/20260503_call_logs_realtime_rls.sql` in the Supabase SQL editor so authenticated users can subscribe to `call_logs` via Realtime (tenant-scoped). Then enable **`call_logs`** under **Database → Replication** for the realtime publication. The Overview and Analytics pages refresh when new rows are inserted.
 npm run dev
 ```
 

--- a/frontend/src/hooks/useSupabaseCallRealtime.ts
+++ b/frontend/src/hooks/useSupabaseCallRealtime.ts
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+import { supabase } from '../lib/supabase';
+
+/**
+ * Vision Phase 2 — live call activity via Supabase Realtime on `call_logs`.
+ * Requires RLS policy + supabase_realtime publication (see backend migrations).
+ */
+export function useSupabaseCallRealtime(
+  tenantId: string | undefined,
+  onInsert?: () => void
+) {
+  useEffect(() => {
+    if (!tenantId || !onInsert) return;
+
+    const channel = supabase
+      .channel(`call_logs:${tenantId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'call_logs',
+          filter: `tenant_id=eq.${tenantId}`,
+        },
+        () => {
+          onInsert();
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [tenantId, onInsert]);
+}

--- a/frontend/src/pages/dashboard/analytics.tsx
+++ b/frontend/src/pages/dashboard/analytics.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { api } from '../../lib/api';
+import { useSupabaseCallRealtime } from '../../hooks/useSupabaseCallRealtime';
 
 interface Props {
   tenant?: any;
@@ -93,11 +94,11 @@ function DonutRing({
   );
 }
 
-export default function Analytics({ tenant, tenants }: Props) {
+export default function Analytics({ tenant }: Props) {
   const [analytics, setAnalytics] = useState<Analytics | null>(null);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
+  const load = useCallback(() => {
     if (!tenant?.id) return;
     setLoading(true);
     api
@@ -106,6 +107,12 @@ export default function Analytics({ tenant, tenants }: Props) {
       .catch(() => {})
       .finally(() => setLoading(false));
   }, [tenant?.id]);
+
+  useSupabaseCallRealtime(tenant?.id, load);
+
+  useEffect(() => {
+    load();
+  }, [load]);
 
   if (!tenant) {
     return (

--- a/frontend/src/pages/dashboard/overview.tsx
+++ b/frontend/src/pages/dashboard/overview.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Link } from 'wouter';
 import { api } from '../../lib/api';
+import { useSupabaseCallRealtime } from '../../hooks/useSupabaseCallRealtime';
 
 interface Props {
   tenant?: any;
@@ -67,8 +68,7 @@ export default function Overview({ tenant }: Props) {
   const [analytics, setAnalytics] = useState<Analytics | null>(null);
   const [calls, setCalls] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
+  const loadData = useCallback(() => {
     if (!tenant?.id) return;
     setLoading(true);
     Promise.all([
@@ -82,6 +82,12 @@ export default function Overview({ tenant }: Props) {
       .catch(() => {})
       .finally(() => setLoading(false));
   }, [tenant?.id]);
+
+  useSupabaseCallRealtime(tenant?.id, loadData);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
 
   if (!tenant) {
     return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Implements items from the Notion runbook **[Vision Phase 2 — Core Voice Engine](https://www.notion.so/34a14fb3db30810eb4d0f5553e8dced6)** (distinct from Integration roadmap Phase 2).

## Linear

**Issue:** `INV-___` (link when filed)

## What shipped

### V2C — Real-time analytics (Supabase Realtime)

- New hook `useSupabaseCallRealtime` subscribes to `INSERT` on `public.call_logs` filtered by `tenant_id`.
- **Overview** and **Analytics** refetch when new call rows arrive (live KPI refresh path).

### V2B — Twilio ↔ tenant routing (building block)

- `POST /api/twilio/resolve-inbound` — Twilio webhook body (`To` / `Called`) → `{ tenant_id }` using digit-normalized match against `tenants.phone_number`. Optional `TWILIO_WEBHOOK_SECRET` → header `X-VoiceOS-Secret`.

### Observability / ingestion

- `POST /api/internal/voice/call-event` — Bearer `INTERNAL_WEBHOOK_SECRET`; inserts `call_logs`, emits Socket.IO `call:created`, triggers Realtime for dashboards.

### V2A fixes

- **`findTenantById` / `listTenants`** now return **`formatTenant`** (camelCase). Previously raw DB rows broke `isRealAgent()` / setup-agent (always saw missing `agentId`).
- **`PATCH /tenants/:id`** maps agent name, language, voice, greeting, business hours (not only ElevenLabs IDs).
- **Google Calendar**: OAuth only constructed when env vars set; tools + auth-url/status avoid crashing when unset.

## Database

Run `backend/migrations/20260503_call_logs_realtime_rls.sql`, then enable **`call_logs`** under Supabase **Database → Replication** for Realtime. Documented in `docs/getting-started.md`.

## Env

See `backend/.env.example`: `TWILIO_WEBHOOK_SECRET`, `INTERNAL_WEBHOOK_SECRET`.

## Verification

- `node --check` on touched backend files
- `npm run type-check` + `npm run lint` in `frontend/` (warnings only, pre-existing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3d89352-01a4-4652-8433-c0f06ffe67ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3d89352-01a4-4652-8433-c0f06ffe67ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

