### PR TITLE
INV-21: Sign in / Sign up with Google (Supabase OAuth)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,6 +31,9 @@ Edit `frontend/.env`. Names must match the example file:
 | `VITE_SUPABASE_URL` | Supabase project URL |
 | `VITE_SUPABASE_ANON_KEY` | Supabase anon (public) key |
 | `VITE_API_BASE_URL` | API base path. Use **`/api`** locally so Vite proxies to the backend (see below). |
+| `VITE_APP_ORIGIN` | Optional. **Site URL** for Google OAuth `redirectTo` (e.g. `http://127.0.0.1:5682`). Must be listed in Supabase **Authentication → URL Configuration**. If unset, the browser’s `window.location.origin` is used. |
+
+**Google sign-in:** Enable the Google provider in **Supabase → Authentication → Providers → Google** and add your app URL (and `http://127.0.0.1:5682` for local dev) under **URL Configuration** → redirect URLs. Add the Google **Client ID/Secret** from Google Cloud Console; ensure redirect `https://<project>.supabase.co/auth/v1/callback` is authorized in Google.
 
 ```bash
 npm run dev

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,7 @@
 VITE_API_BASE_URL=/api
 VITE_SUPABASE_URL=https://your-project-id.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key
+
+# Optional. OAuth redirect after Google sign-in must match an allowed URL in
+# Supabase → Authentication → URL Configuration. Defaults to window.location.origin.
+# VITE_APP_ORIGIN=http://127.0.0.1:5682

--- a/frontend/src/components/GoogleSignInButton.tsx
+++ b/frontend/src/components/GoogleSignInButton.tsx
@@ -1,0 +1,52 @@
+type Props = {
+  onClick: () => void;
+  loading?: boolean;
+  variant?: 'dark' | 'light';
+};
+
+function GoogleMark({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" width="18" height="18">
+      <path
+        fill="#4285F4"
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+      />
+      <path
+        fill="#34A853"
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+      />
+      <path
+        fill="#EA4335"
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+      />
+    </svg>
+  );
+}
+
+export default function GoogleSignInButton({
+  onClick,
+  loading,
+  variant = 'dark',
+}: Props) {
+  const base =
+    variant === 'dark'
+      ? 'w-full flex items-center justify-center gap-2.5 border border-[#333] bg-[#111] hover:bg-[#1a1a1a] text-white'
+      : 'w-full flex items-center justify-center gap-2.5 border border-[#ccc] bg-white hover:bg-gray-50 text-gray-900';
+
+  return (
+    <button
+      type="button"
+      disabled={loading}
+      onClick={onClick}
+      className={`${base} font-medium py-2.5 rounded-md text-sm transition-colors disabled:opacity-50`}
+      formNoValidate
+    >
+      <GoogleMark />
+      {loading ? 'Redirecting…' : 'Continue with Google'}
+    </button>
+  );
+}

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,7 +1,35 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 import { sessionLoadingState, sessionUserState } from '../state/appState';
 import { supabase } from './supabase';
+
+/** Public site URL for OAuth redirects (must match Supabase Auth → URL Configuration). */
+export function getAppOrigin(): string {
+  const fromEnv = import.meta.env.VITE_APP_ORIGIN;
+  if (fromEnv && typeof fromEnv === 'string' && fromEnv.length > 0) {
+    return fromEnv.replace(/\/$/, '');
+  }
+  if (typeof window !== 'undefined') {
+    return window.location.origin;
+  }
+  return '';
+}
+
+function displayNameFromUser(user: {
+  email?: string | null;
+  user_metadata?: Record<string, unknown>;
+}): string {
+  const meta = user.user_metadata || {};
+  const name = meta.name;
+  if (typeof name === 'string' && name.trim()) return name.trim();
+  const full = meta.full_name;
+  if (typeof full === 'string' && full.trim()) return full.trim();
+  const given = meta.given_name;
+  const family = meta.family_name;
+  const parts = [given, family].filter((x) => typeof x === 'string' && x.trim());
+  if (parts.length) return parts.join(' ');
+  return user.email?.split('@')[0] || '';
+}
 
 export const authClient = {
   useSession() {
@@ -15,14 +43,13 @@ export const authClient = {
       } = await supabase.auth.getSession();
 
       if (session?.user) {
-        // Extract metadata we stored
         const meta = session.user.user_metadata || {};
         setUser({
           id: session.user.id,
           email: session.user.email || '',
-          name: meta.name || session.user.email?.split('@')[0] || '',
-          role: meta.role || 'tenant_admin',
-          tenantId: meta.tenantId || '',
+          name: displayNameFromUser(session.user),
+          role: (meta.role as string) || 'tenant_admin',
+          tenantId: (meta.tenantId as string) || '',
         });
       } else {
         setUser(null);
@@ -69,6 +96,29 @@ export const authClient = {
       const { data, error } = await supabase.auth.signInWithPassword({
         email: body.email,
         password: body.password,
+      });
+      return { data, error };
+    },
+    /** Supabase Google provider must be enabled. Add redirect URL in Dashboard → Auth → URL Configuration. */
+    google: async (options?: { redirectPath?: string }) => {
+      const origin = getAppOrigin();
+      if (!origin) {
+        return {
+          data: null,
+          error: new Error('Could not resolve app origin for OAuth redirect'),
+        };
+      }
+      const path = options?.redirectPath ?? '/dashboard';
+      const redirectTo = `${origin}${path.startsWith('/') ? path : `/${path}`}`;
+      const { data, error } = await supabase.auth.signInWithOAuth({
+        provider: 'google',
+        options: {
+          redirectTo,
+          queryParams: {
+            access_type: 'offline',
+            prompt: 'consent',
+          },
+        },
       });
       return { data, error };
     },

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -26,7 +26,9 @@ function displayNameFromUser(user: {
   if (typeof full === 'string' && full.trim()) return full.trim();
   const given = meta.given_name;
   const family = meta.family_name;
-  const parts = [given, family].filter((x) => typeof x === 'string' && x.trim());
+  const parts = [given, family].filter(
+    (x) => typeof x === 'string' && x.trim()
+  );
   if (parts.length) return parts.join(' ');
   return user.email?.split('@')[0] || '';
 }

--- a/frontend/src/pages/sign-in.tsx
+++ b/frontend/src/pages/sign-in.tsx
@@ -1,12 +1,57 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'wouter';
 import { authClient } from '../lib/auth';
+import GoogleSignInButton from '../components/GoogleSignInButton';
 
 export default function SignIn() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [googleLoading, setGoogleLoading] = useState(false);
+
+  useEffect(() => {
+    const parseOAuthError = (raw: string) => {
+      const params = new URLSearchParams(raw.replace(/^#/, ''));
+      const desc =
+        params.get('error_description') ||
+        params.get('error_code') ||
+        params.get('error');
+      return desc ? decodeURIComponent(desc.replace(/\+/g, ' ')) : null;
+    };
+    const fromHash = typeof window !== 'undefined' ? window.location.hash : '';
+    const fromSearch =
+      typeof window !== 'undefined' ? window.location.search : '';
+    let msg = fromHash ? parseOAuthError(fromHash) : null;
+    if (!msg && fromSearch) {
+      const q = new URLSearchParams(fromSearch.replace(/^\?/, ''));
+      msg =
+        q.get('error_description') ||
+        q.get('error_code') ||
+        q.get('error');
+      if (msg) msg = decodeURIComponent(msg.replace(/\+/g, ' '));
+    }
+    if (msg) {
+      setError(msg);
+      window.history.replaceState(null, '', window.location.pathname);
+    }
+  }, []);
+
+  const handleGoogle = async () => {
+    setError('');
+    setGoogleLoading(true);
+    try {
+      const res = await authClient.signIn.google({ redirectPath: '/dashboard' });
+      if (res.error) {
+        setError(res.error.message || 'Google sign-in failed');
+        setGoogleLoading(false);
+      }
+      // Success: browser redirects to Google
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Google sign-in failed');
+      setGoogleLoading(false);
+    }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -46,6 +91,23 @@ export default function SignIn() {
             Sign in to your VoiceOS account
           </p>
 
+          {error && (
+            <div className="text-xs text-[#E00] bg-[#E00]/10 border border-[#E00]/30 rounded-md px-3 py-2 mb-4">
+              {error}
+            </div>
+          )}
+
+          <GoogleSignInButton onClick={handleGoogle} loading={googleLoading} />
+
+          <div className="relative my-5">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-[#222]" />
+            </div>
+            <div className="relative flex justify-center text-xs">
+              <span className="bg-[#0A0A0A] px-3 text-[#666]">or email</span>
+            </div>
+          </div>
+
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
               <label className="block text-xs font-medium text-[#A1A1A1] mb-1.5">
@@ -73,11 +135,6 @@ export default function SignIn() {
                 className="w-full bg-[#111] border border-[#333] focus:border-white rounded-md px-3.5 py-2.5 text-sm text-white placeholder-[#666] outline-none transition-colors"
               />
             </div>
-            {error && (
-              <div className="text-xs text-[#E00] bg-[#E00]/10 border border-[#E00]/30 rounded-md px-3 py-2">
-                {error}
-              </div>
-            )}
             <button
               type="submit"
               disabled={loading}

--- a/frontend/src/pages/sign-in.tsx
+++ b/frontend/src/pages/sign-in.tsx
@@ -25,10 +25,7 @@ export default function SignIn() {
     let msg = fromHash ? parseOAuthError(fromHash) : null;
     if (!msg && fromSearch) {
       const q = new URLSearchParams(fromSearch.replace(/^\?/, ''));
-      msg =
-        q.get('error_description') ||
-        q.get('error_code') ||
-        q.get('error');
+      msg = q.get('error_description') || q.get('error_code') || q.get('error');
       if (msg) msg = decodeURIComponent(msg.replace(/\+/g, ' '));
     }
     if (msg) {
@@ -41,7 +38,9 @@ export default function SignIn() {
     setError('');
     setGoogleLoading(true);
     try {
-      const res = await authClient.signIn.google({ redirectPath: '/dashboard' });
+      const res = await authClient.signIn.google({
+        redirectPath: '/dashboard',
+      });
       if (res.error) {
         setError(res.error.message || 'Google sign-in failed');
         setGoogleLoading(false);

--- a/frontend/src/pages/sign-in.tsx
+++ b/frontend/src/pages/sign-in.tsx
@@ -17,7 +17,7 @@ export default function SignIn() {
         params.get('error_description') ||
         params.get('error_code') ||
         params.get('error');
-      return desc ? decodeURIComponent(desc.replace(/\+/g, ' ')) : null;
+      return desc;
     };
     const fromHash = typeof window !== 'undefined' ? window.location.hash : '';
     const fromSearch =
@@ -26,7 +26,6 @@ export default function SignIn() {
     if (!msg && fromSearch) {
       const q = new URLSearchParams(fromSearch.replace(/^\?/, ''));
       msg = q.get('error_description') || q.get('error_code') || q.get('error');
-      if (msg) msg = decodeURIComponent(msg.replace(/\+/g, ' '));
     }
     if (msg) {
       setError(msg);

--- a/frontend/src/pages/sign-up.tsx
+++ b/frontend/src/pages/sign-up.tsx
@@ -18,7 +18,7 @@ export default function SignUp() {
         params.get('error_description') ||
         params.get('error_code') ||
         params.get('error');
-      return desc ? decodeURIComponent(desc.replace(/\+/g, ' ')) : null;
+      return desc;
     };
     const fromHash = typeof window !== 'undefined' ? window.location.hash : '';
     const fromSearch =
@@ -27,7 +27,6 @@ export default function SignUp() {
     if (!msg && fromSearch) {
       const q = new URLSearchParams(fromSearch.replace(/^\?/, ''));
       msg = q.get('error_description') || q.get('error_code') || q.get('error');
-      if (msg) msg = decodeURIComponent(msg.replace(/\+/g, ' '));
     }
     if (msg) {
       setError(msg);

--- a/frontend/src/pages/sign-up.tsx
+++ b/frontend/src/pages/sign-up.tsx
@@ -26,10 +26,7 @@ export default function SignUp() {
     let msg = fromHash ? parseOAuthError(fromHash) : null;
     if (!msg && fromSearch) {
       const q = new URLSearchParams(fromSearch.replace(/^\?/, ''));
-      msg =
-        q.get('error_description') ||
-        q.get('error_code') ||
-        q.get('error');
+      msg = q.get('error_description') || q.get('error_code') || q.get('error');
       if (msg) msg = decodeURIComponent(msg.replace(/\+/g, ' '));
     }
     if (msg) {

--- a/frontend/src/pages/sign-up.tsx
+++ b/frontend/src/pages/sign-up.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'wouter';
 import { authClient } from '../lib/auth';
+import GoogleSignInButton from '../components/GoogleSignInButton';
 
 export default function SignUp() {
   const [name, setName] = useState('');
@@ -8,6 +9,51 @@ export default function SignUp() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [googleLoading, setGoogleLoading] = useState(false);
+
+  useEffect(() => {
+    const parseOAuthError = (raw: string) => {
+      const params = new URLSearchParams(raw.replace(/^#/, ''));
+      const desc =
+        params.get('error_description') ||
+        params.get('error_code') ||
+        params.get('error');
+      return desc ? decodeURIComponent(desc.replace(/\+/g, ' ')) : null;
+    };
+    const fromHash = typeof window !== 'undefined' ? window.location.hash : '';
+    const fromSearch =
+      typeof window !== 'undefined' ? window.location.search : '';
+    let msg = fromHash ? parseOAuthError(fromHash) : null;
+    if (!msg && fromSearch) {
+      const q = new URLSearchParams(fromSearch.replace(/^\?/, ''));
+      msg =
+        q.get('error_description') ||
+        q.get('error_code') ||
+        q.get('error');
+      if (msg) msg = decodeURIComponent(msg.replace(/\+/g, ' '));
+    }
+    if (msg) {
+      setError(msg);
+      window.history.replaceState(null, '', window.location.pathname);
+    }
+  }, []);
+
+  const handleGoogle = async () => {
+    setError('');
+    setGoogleLoading(true);
+    try {
+      const res = await authClient.signIn.google({
+        redirectPath: '/onboarding',
+      });
+      if (res.error) {
+        setError(res.error.message || 'Google sign-up failed');
+        setGoogleLoading(false);
+      }
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Google sign-up failed');
+      setGoogleLoading(false);
+    }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -46,6 +92,23 @@ export default function SignUp() {
           <p className="text-sm text-[#A1A1A1] mb-6">
             Get your AI agent live in 10 minutes
           </p>
+
+          {error && (
+            <div className="text-xs text-[#E00] bg-[#E00]/10 border border-[#E00]/30 rounded-md px-3 py-2 mb-4">
+              {error}
+            </div>
+          )}
+
+          <GoogleSignInButton onClick={handleGoogle} loading={googleLoading} />
+
+          <div className="relative my-5">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-[#222]" />
+            </div>
+            <div className="relative flex justify-center text-xs">
+              <span className="bg-[#0A0A0A] px-3 text-[#666]">or email</span>
+            </div>
+          </div>
 
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
@@ -88,11 +151,6 @@ export default function SignUp() {
                 className="w-full bg-[#111] border border-[#333] focus:border-white rounded-md px-3.5 py-2.5 text-sm text-white placeholder-[#666] outline-none transition-colors"
               />
             </div>
-            {error && (
-              <div className="text-xs text-[#E00] bg-[#E00]/10 border border-[#E00]/30 rounded-md px-3 py-2">
-                {error}
-              </div>
-            )}
             <button
               type="submit"
               disabled={loading}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,13 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SUPABASE_URL: string;
+  readonly VITE_SUPABASE_ANON_KEY: string;
+  readonly VITE_API_BASE_URL?: string;
+  /** Optional; used as OAuth redirect base for Google sign-in */
+  readonly VITE_APP_ORIGIN?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Supabase **Sign in with Google** for email/password pages.

- `authClient.signIn.google()` using `signInWithOAuth` with `redirectTo` to `/dashboard` (sign-in) or `/onboarding` (sign-up)
- Google display name from `user_metadata` (`full_name`, `given_name` + `family_name`, etc.)
- Optional `VITE_APP_ORIGIN` in `frontend/.env.example`; setup notes in `docs/getting-started.md`

**PR links to `INV-21` in the title** for the GitHub ↔ Linear integration.

**Supabase:** enable Google provider; under URL Configuration add `http://127.0.0.1:5682/**` and production app URLs. Google Cloud must allow `https://<project>.supabase.co/auth/v1/callback`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3d89352-01a4-4652-8433-c0f06ffe67ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3d89352-01a4-4652-8433-c0f06ffe67ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

