### PR TITLE
feat(inv-16): call logs Realtime migration + pg as devDependency

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,6 +5,9 @@ CLIENT_ORIGIN=http://127.0.0.1:5682
 SUPABASE_URL=https://your-project-id.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
+# Optional — Postgres URI for npm run migrate:call-logs-realtime (INV-16). Same host as Supabase → Settings → Database.
+# SUPABASE_DATABASE_URL=postgresql://postgres.[ref]:[PASSWORD]@...
+
 # ElevenLabs + Twilio are required for real agent creation and outbound calls.
 ELEVENLABS_API_KEY=
 TWILIO_ACCOUNT_SID=

--- a/backend/migrations/20260503_call_logs_realtime_publication.sql
+++ b/backend/migrations/20260503_call_logs_realtime_publication.sql
@@ -1,0 +1,16 @@
+-- INV-16 / Vision Phase 2: register call_logs with Supabase Realtime publication.
+-- Idempotent: skips if already in publication.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime'
+      AND schemaname = 'public'
+      AND tablename = 'call_logs'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.call_logs;
+  END IF;
+END;
+$$;

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,12 +11,12 @@
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "googleapis": "^171.4.0",
-        "pg": "^8.20.0",
         "socket.io": "^4.8.3"
       },
       "devDependencies": {
         "@types/node": "^25.3.5",
-        "concurrently": "^9.2.1"
+        "concurrently": "^9.2.1",
+        "pg": "^8.20.0"
       }
     },
     "node_modules/@socket.io/component-emitter": {
@@ -1301,6 +1301,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pg-connection-string": "^2.12.0",
@@ -1328,6 +1329,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
       "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -1335,12 +1337,14 @@
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
       "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=4.0.0"
@@ -1350,6 +1354,7 @@
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
       "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "pg": ">=8.0"
@@ -1359,12 +1364,14 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
       "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pg-int8": "1.0.1",
@@ -1381,6 +1388,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
       "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "split2": "^4.1.0"
@@ -1390,6 +1398,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -1399,6 +1408,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
       "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1408,6 +1418,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
       "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1417,6 +1428,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xtend": "^4.0.0"
@@ -1784,6 +1796,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
@@ -1948,6 +1961,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4"

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "googleapis": "^171.4.0",
+        "pg": "^8.20.0",
         "socket.io": "^4.8.3"
       },
       "devDependencies": {
@@ -1296,6 +1297,134 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1651,6 +1780,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1805,6 +1943,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,11 +13,11 @@
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "googleapis": "^171.4.0",
-    "pg": "^8.20.0",
     "socket.io": "^4.8.3"
   },
   "devDependencies": {
     "@types/node": "^25.3.5",
+    "pg": "^8.20.0",
     "concurrently": "^9.2.1"
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "dev": "node server/index.js",
-    "start": "node server/index.js"
+    "start": "node server/index.js",
+    "migrate:call-logs-realtime": "node scripts/apply-call-logs-realtime.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.48.1",
@@ -12,6 +13,7 @@
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "googleapis": "^171.4.0",
+    "pg": "^8.20.0",
     "socket.io": "^4.8.3"
   },
   "devDependencies": {

--- a/backend/scripts/apply-call-logs-realtime.mjs
+++ b/backend/scripts/apply-call-logs-realtime.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * INV-16: Apply call_logs Realtime migration (RLS + publication) via Postgres.
+ *
+ * Requires a direct Postgres URL (not the Supabase anon key):
+ *   Supabase Dashboard → Project Settings → Database → Connection string (URI)
+ *
+ * Usage:
+ *   cd backend && npm run migrate:call-logs-realtime
+ *
+ * Env (backend/.env):
+ *   SUPABASE_DATABASE_URL=postgresql://postgres.[ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres
+ *   or DATABASE_URL=...
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import pg from "pg";
+import dotenv from "dotenv";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+dotenv.config({ path: path.resolve(__dirname, "../.env") });
+
+const databaseUrl =
+  process.env.SUPABASE_DATABASE_URL ||
+  process.env.DATABASE_URL ||
+  process.env.POSTGRES_URL ||
+  "";
+
+async function main() {
+  if (!databaseUrl) {
+    console.error(
+      "[INV-16] No SUPABASE_DATABASE_URL or DATABASE_URL in backend/.env.\n" +
+        "Copy the Postgres connection URI from Supabase → Settings → Database."
+    );
+    process.exit(1);
+  }
+
+  const migrationsDir = path.resolve(__dirname, "../migrations");
+  const files = [
+    "20260503_call_logs_realtime_rls.sql",
+    "20260503_call_logs_realtime_publication.sql",
+  ];
+
+  const client = new pg.Client({ connectionString: databaseUrl });
+  await client.connect();
+
+  try {
+    for (const file of files) {
+      const sqlPath = path.join(migrationsDir, file);
+      const sql = fs.readFileSync(sqlPath, "utf8");
+      console.log(`[INV-16] Applying ${file}…`);
+      await client.query(sql);
+    }
+    console.log("[INV-16] Migrations applied successfully.");
+    console.log(
+      "[INV-16] Verify: Dashboard → Database → Replication → confirm call_logs is listed.\n" +
+        "[INV-16] Smoke test: insert a call_logs row for your tenant and watch Overview/Analytics refresh."
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error("[INV-16] Failed:", err.message);
+  process.exit(1);
+});

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -62,6 +62,7 @@ Edit `backend/.env`:
 | `CLIENT_ORIGIN` | **`http://127.0.0.1:5682`** (CORS + Socket.IO) |
 | `SUPABASE_URL` | Same project URL as the frontend |
 | `SUPABASE_SERVICE_ROLE_KEY` | Service role key (**server only**; never in Vite env) |
+| `SUPABASE_DATABASE_URL` | Optional Postgres URI — **INV-16** migration script only ([see below](#inv-16-call_logs-realtime-supabase)) |
 | `ELEVENLABS_API_KEY` | Required for real agent creation / voice paths when used |
 | `TWILIO_ACCOUNT_SID` | Required for outbound calls when used |
 | `TWILIO_AUTH_TOKEN` | |
@@ -71,11 +72,31 @@ Edit `backend/.env`:
 | `TWILIO_WEBHOOK_SECRET` | Optional; `POST /api/twilio/resolve-inbound` accepts header `X-VoiceOS-Secret` when set |
 | `INTERNAL_WEBHOOK_SECRET` | Optional; `Authorization: Bearer …` for `POST /api/internal/voice/call-event` |
 
-**Vision Phase 2 (live analytics):** Run `backend/migrations/20260503_call_logs_realtime_rls.sql` in the Supabase SQL editor so authenticated users can subscribe to `call_logs` via Realtime (tenant-scoped). Then enable **`call_logs`** under **Database → Replication** for the realtime publication. The Overview and Analytics pages refresh when new rows are inserted.
+```bash
 npm run dev
 ```
 
 **Listen address:** `http://127.0.0.1:5000` (API + Socket.IO on the same port).
+
+#### INV-16: `call_logs` Realtime (Supabase)
+
+Live refreshes on **Overview** and **Analytics** need tenant-scoped **SELECT** on `call_logs` and the table in the **`supabase_realtime`** publication.
+
+1. **Option A — SQL Editor (no local DB URL):** Run these files in order in **Supabase → SQL Editor**:
+   - `backend/migrations/20260503_call_logs_realtime_rls.sql`
+   - `backend/migrations/20260503_call_logs_realtime_publication.sql`  
+   If the publication block errors with permissions, keep RLS only and use **Database → Replication** to toggle **`call_logs`** for Realtime.
+
+2. **Option B — script:** Add **`SUPABASE_DATABASE_URL`** (Postgres URI from **Settings → Database**) to `backend/.env`, then:
+
+```bash
+cd backend
+npm run migrate:call-logs-realtime
+```
+
+3. **Dashboard:** **Database → Replication** — ensure **`call_logs`** is enabled for Realtime (matches publication step).
+
+4. **Verify:** Sign in, open **Overview**, trigger a new `call_logs` INSERT for your tenant (e.g. API or webhook); counts should refresh without a full reload.
 
 ### Run frontend + backend together
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Call logs Realtime (INV-16)**: one-time migration script and related work.
- **This commit**: `pg` is only used by `scripts/apply-call-logs-realtime.mjs` (not the Express server). It was moved from `dependencies` to `devDependencies` so production installs skip it unless dev tooling is installed.

## Verification

- `grep` confirms `pg` is imported only in `scripts/apply-call-logs-realtime.mjs`.
- `npm install` in `backend/` after the change succeeds.

## Notes

- Run `npm run migrate:call-logs-realtime` in an environment where dev dependencies are installed (e.g. CI with `npm ci` default, or local dev). `npm install --omit=dev` in production will not install `pg`; the migration is not part of the runtime server.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3d89352-01a4-4652-8433-c0f06ffe67ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3d89352-01a4-4652-8433-c0f06ffe67ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

