### PR TITLE
feat(phase2): harden golden path — API errors, calendar OAuth, Shopif…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,9 +14,13 @@ TWILIO_ACCOUNT_SID=
 TWILIO_AUTH_TOKEN=
 TWILIO_PHONE_NUMBER=
 
-# Optional Google integrations.
+# Optional Google integrations (Calendar uses the Node API directly — separate from Supabase “Sign in with Google”).
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+# Exact URL registered under Google Cloud → Credentials → OAuth client → Authorized redirect URIs.
+# Local: http://localhost:5000/api/auth/google/callback
+# Hosted API (no custom domain): https://<your-platform-host>/api/auth/google/callback
+# GOOGLE_OAUTH_REDIRECT_URI=http://localhost:5000/api/auth/google/callback
 
 # Vision Phase 2 — webhooks
 # Optional shared secret for POST /api/twilio/resolve-inbound (header X-VoiceOS-Secret)

--- a/backend/server/routes/api.js
+++ b/backend/server/routes/api.js
@@ -25,11 +25,16 @@ export function createApiRouter(io) {
   const oauthConfigured =
     Boolean(process.env.GOOGLE_CLIENT_ID) && Boolean(process.env.GOOGLE_CLIENT_SECRET);
 
+  /** Must match an "Authorized redirect URI" for this Web client in Google Cloud Console (not Supabase's callback). */
+  const googleOAuthRedirectUri =
+    process.env.GOOGLE_OAUTH_REDIRECT_URI?.trim() ||
+    "http://localhost:5000/api/auth/google/callback";
+
   const oauth2Client = oauthConfigured
     ? new google.auth.OAuth2(
         process.env.GOOGLE_CLIENT_ID,
         process.env.GOOGLE_CLIENT_SECRET,
-        "http://localhost:5000/api/auth/google/callback"
+        googleOAuthRedirectUri
       )
     : null;
 

--- a/backend/server/routes/api.js
+++ b/backend/server/routes/api.js
@@ -127,7 +127,11 @@ export function createApiRouter(io) {
     const tenantId = req.query.state;
     if (!code || !tenantId) return res.status(400).send("Invalid callback");
     if (!oauth2Client) {
-      return res.status(503).send("Google OAuth is not configured on this server.");
+      return res
+        .status(503)
+        .send(
+          "<html><body><h1>Google OAuth not configured</h1><p>The server is missing GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET, so calendar connection is unavailable.</p></body></html>"
+        );
     }
 
     try {
@@ -312,7 +316,6 @@ export function createApiRouter(io) {
       if (!calendar) {
         return res.json({ result: "Google Calendar OAuth is not configured on the server." });
       }
-
       const timeMin = new Date(`${requestedDate}T00:00:00.000Z`);
       const timeMax = new Date(`${requestedDate}T23:59:59.999Z`);
 

--- a/backend/server/services/repositories.js
+++ b/backend/server/services/repositories.js
@@ -128,23 +128,28 @@ export async function updateTenant(id, payload) {
     updates.business_hours_end = payload.businessHoursEnd;
   }
 
-  if (payload.metadata?.shopify !== undefined) {
+  if (payload.metadata && Object.prototype.hasOwnProperty.call(payload.metadata, "shopify")) {
     const { data: rawRow } = await supabase
       .from('tenants')
       .select('settings')
       .eq('id', id)
       .single();
     const prev =
-      rawRow?.settings && typeof rawRow.settings === 'object' ? rawRow.settings : {};
-    const prevShopify = prev.shopify && typeof prev.shopify === 'object' ? prev.shopify : {};
+      rawRow?.settings && typeof rawRow.settings === 'object' ? { ...rawRow.settings } : {};
     const nextShopify = payload.metadata.shopify;
-    updates.settings = {
-      ...prev,
-      shopify: {
-        storeUrl: nextShopify.storeUrl ?? prevShopify.storeUrl ?? "",
-        adminToken: nextShopify.adminToken ?? prevShopify.adminToken ?? "",
-      },
-    };
+    if (nextShopify === null) {
+      delete prev.shopify;
+      updates.settings = prev;
+    } else if (typeof nextShopify === "object") {
+      const prevShopify = prev.shopify && typeof prev.shopify === "object" ? prev.shopify : {};
+      updates.settings = {
+        ...prev,
+        shopify: {
+          storeUrl: nextShopify.storeUrl ?? prevShopify.storeUrl ?? "",
+          adminToken: nextShopify.adminToken ?? prevShopify.adminToken ?? "",
+        },
+      };
+    }
   }
 
   const { data, error } = await supabase.from('tenants').update(updates).eq('id', id).select('*').single();

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -21,8 +21,27 @@ async function req(path: string, opts?: RequestInit) {
     headers,
     ...opts,
   });
-  if (!res.ok) throw new Error(await res.text());
-  return res.json();
+  const text = await res.text();
+  if (!res.ok) {
+    let message = text;
+    try {
+      const j = JSON.parse(text) as { error?: string };
+      if (typeof j?.error === 'string') message = j.error;
+    } catch {
+      /* keep raw body */
+    }
+    const err = new Error(
+      message || res.statusText || 'Request failed'
+    ) as Error & {
+      status: number;
+      body?: string;
+    };
+    err.status = res.status;
+    err.body = text;
+    throw err;
+  }
+  if (!text) return null as unknown;
+  return JSON.parse(text) as unknown;
 }
 
 export const api = {

--- a/frontend/src/pages/dashboard/integrations.tsx
+++ b/frontend/src/pages/dashboard/integrations.tsx
@@ -69,11 +69,14 @@ export default function Integrations({ tenant }: Props) {
     if (!tenant?.id) return;
     setConnecting('calendar');
     try {
-      const r = await api.get(`/tenants/${tenant.id}/calendar/auth-url`);
+      const r = (await api.get(`/tenants/${tenant.id}/calendar/auth-url`)) as {
+        url?: string | null;
+        error?: string;
+      };
       if (!r.url) {
         showMsg(
           r.error ||
-            'Calendar OAuth is not available. Configure GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET in backend/.env.',
+            'Could not get a Google OAuth URL. Check backend env and calendar configuration.',
           false
         );
         return;
@@ -92,8 +95,13 @@ export default function Integrations({ tenant }: Props) {
         }
       };
       window.addEventListener('message', onMsg);
-    } catch (e: any) {
-      showMsg('Failed: ' + e.message, false);
+    } catch (e: unknown) {
+      const err = e as Error & { status?: number };
+      const detail =
+        err.status === 503
+          ? 'Google OAuth is not configured on the server (add GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET).'
+          : err.message || 'Request failed';
+      showMsg('Failed: ' + detail, false);
     }
     setConnecting(null);
   };

--- a/frontend/src/pages/onboarding.tsx
+++ b/frontend/src/pages/onboarding.tsx
@@ -377,9 +377,9 @@ export default function Onboarding() {
                   <button
                     onClick={async () => {
                       try {
-                        const res = await api.get(
+                        const res = (await api.get(
                           `/tenants/${tenantId}/calendar/auth-url`
-                        );
+                        )) as { url?: string | null; error?: string };
                         if (!res.url) {
                           alert(
                             res.error ||
@@ -397,11 +397,12 @@ export default function Onboarding() {
                           { once: true }
                         );
                       } catch (e: unknown) {
+                        const err = e as Error & { status?: number };
                         const msg =
-                          e instanceof Error ? e.message : 'Request failed';
+                          err instanceof Error ? err.message : 'Request failed';
                         alert(
-                          msg.includes('503')
-                            ? 'Google OAuth is not configured. Add credentials to backend/.env or skip below.'
+                          err.status === 503
+                            ? 'Google OAuth is not configured. Add GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET to backend/.env, or use Skip below.'
                             : msg
                         );
                       }


### PR DESCRIPTION
…y settings

- Parse JSON error bodies in api client; attach status/body for UI branches\n- Integrations and onboarding: detect 503 for missing Google OAuth env\n- Google OAuth callback: HTML error page when OAuth is not configured\n- updateTenant: allow clearing Shopify via metadata.shopify === null

## Purpose
What does this PR accomplish? (e.g. "Migrates Supabase auth", "Adds new profile modal")

## Linear
🎫 **Issue:** `INV-___` (required for feature/fix work — team key **INV**)

**Branch:** If tied to Linear, prefer `feat/inv-___-short-slug` or `fix/inv-___-short-slug` (match the issue id).

**Preview:** After CI, paste the **Vercel preview URL** if this change needs UI or auth verification.

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💄 UI/UX styling
- [ ] 🛠️ Refactoring / Technical Debt
- [ ] 📚 Documentation

## Checklist
Before asking for a review, please verify the following:
- [x] My code strictly follows the application's aesthetic guidelines (Tailwind CSS, glassmorphism, responsive).
- [ ] I have verified this behavior locally.
- [ ] Any `.env` changes required have been securely documented in `README.md` or Notion, and never committed to Git.
- [ ] CI Pipeline checks are currently passing.

## Video / Screenshots
(If a UI change, please drag and drop screenshot or video here)

## Review Priority
- [ ] 🚨 Urgent (Hotfix for production)
- [ ] 🟠 High (Blocks other work)
- [ ] 🟢 Normal / Low

## Additional Comments
(Any specific code segments you want reviewers to look closely at?)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth configuration/callback handling and tenant settings persistence; mistakes could break calendar connection flows or inadvertently mutate tenant `settings` data. Frontend API error parsing changes could affect error handling assumptions across the UI.
> 
> **Overview**
> Improves **Google Calendar OAuth configuration** by introducing `GOOGLE_OAUTH_REDIRECT_URI` (documented in `.env.example`) and wiring it into the backend OAuth client, plus returning a clearer HTML error page on `/api/auth/google/callback` when OAuth env vars are missing.
> 
> Hardens the **frontend request/error path** by parsing JSON error bodies, attaching `status`/raw `body` to thrown errors, and updating Integrations + Onboarding flows to branch on `503` for missing Google OAuth configuration.
> 
> Updates `updateTenant` to allow **clearing Shopify settings** by sending `metadata.shopify: null`, and tightens detection of an explicitly provided `metadata.shopify` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a7d22527a6e994685524a11d4f78374ef2b9dea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->